### PR TITLE
Wrap transfer, transferFrom and approve in require

### DIFF
--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -66,16 +66,16 @@ contract Medianizer is DSValue {
     }
 
     function push (uint256 amt, ERC20 tok) {
-    	if (tokas[address(tok)] == false) {
-            tokas[address(tok)] = true;
-            for (uint96 j = 1; j < uint96(next); j++) {
-	    		tok.approve(values[bytes12(j)], 2**256-1);
-	    	}
-	    	tokas[address(tok)] = true;
+      if (tokas[address(tok)] == false) {
+        tokas[address(tok)] = true;
+        for (uint96 j = 1; j < uint96(next); j++) {
+          require(tok.approve(values[bytes12(j)], 2**256-1));
         }
-    	for (uint96 i = 1; i < uint96(next); i++) {
-    		tok.transferFrom(msg.sender, values[bytes12(i)], uint(div(uint128(amt), uint128(next) - 1)));
-    	}
+        tokas[address(tok)] = true;
+      }
+      for (uint96 i = 1; i < uint96(next); i++) {
+      require(tok.transferFrom(msg.sender, values[bytes12(i)], uint(div(uint128(amt), uint128(next) - 1))));
+      }
     }
 
     function poke() {

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -43,7 +43,7 @@ contract Oracle is DSMath {
     }
 
     function push(uint128 amt, ERC20 tok_) public {
-        tok_.transferFrom(msg.sender, address(this), uint256(amt));
+        require(tok_.transferFrom(msg.sender, address(this), uint256(amt)));
     }
     
     function bill() public view returns (uint256) {
@@ -98,7 +98,7 @@ contract Oracle is DSMath {
     function ward() internal { // Reward
         gain = wmul(wmul(lval, dis), prem);
         if (tok.balanceOf(address(this)) >= gain && dis > 0) {
-            tok.transfer(owed, gain);
+            require(tok.transfer(owed, gain));
         }
     }
 }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -21,7 +21,7 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     function pack(uint128 pmt_, ERC20 tok_) { // payment
         require(uint32(now) > lag);
-        link.transferFrom(msg.sender, address(this), uint(pmt_));
+        require(link.transferFrom(msg.sender, address(this), uint(pmt_)));
         pmt = pmt_;
         dis = 0;
         lag = uint32(now) + DELAY;
@@ -58,7 +58,7 @@ contract ChainLink is ChainlinkClient, Oracle {
     function ward() internal { // Reward
         gain = wmul(wmul(lval, dis), prem);
         if (tok.balanceOf(address(this)) >= min(maxr, gain) && dis > 0) {
-            tok.transfer(owed, min(maxr, gain));
+            require(tok.transfer(owed, min(maxr, gain)));
         }
     }
 

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -31,7 +31,7 @@ contract Oraclize is usingOraclize, Oracle {
     function pack(uint128 pmt_, ERC20 tok_) { // payment
         require(uint32(now) > lag);
         require(pmt_ == oraclize_getPrice("URL"));
-        weth.transferFrom(msg.sender, address(this), uint(pmt_));
+        require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
         pmt = pmt_;
         dis = 0;
         lag = uint32(now) + DELAY;


### PR DESCRIPTION
Wrap transfer, transferFrom and approve in require

ERC20's `transfer`, `transferFrom`, and `approve` functions return a boolean indicating success. Many implementations revert failed transfers, but certainly not all do. Because of this, the return value must be checked. Otherwise it may seem that the call succeeded when it actually failed.