### PR TITLE
Improve oracle inheritance model

### DIFF
--- a/contracts/DSValue.sol
+++ b/contracts/DSValue.sol
@@ -20,8 +20,4 @@ contract DSValue is DSMath {
         val = wut;
         has = true;
     }
-
-    function setMax(uint256 maxr) public {
-        has = true;
-    }
 }

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -67,12 +67,17 @@ contract Medianizer is DSMath {
       Oracle(values[bytes12(3)]).setMax(maxr_);
       Oracle(values[bytes12(4)]).setMax(maxr_);
       Oracle(values[bytes12(5)]).setMax(maxr_);
+      Oracle(values[bytes12(6)]).setMax(maxr_);
+      Oracle(values[bytes12(7)]).setMax(maxr_);
+      Oracle(values[bytes12(8)]).setMax(maxr_);
+      Oracle(values[bytes12(9)]).setMax(maxr_);
+      Oracle(values[bytes12(10)]).setMax(maxr_);
     }
 
     function peek() constant returns (bytes32, bool) {
         return (val,has);
     }
-    
+
     function read() constant returns (bytes32) {
         var (wut, has) = peek();
         assert(has);

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -1,9 +1,13 @@
 import "./ERC20.sol";
-import "./DSValue.sol";
+import "./Oracle.sol";
+import "./DSMath.sol";
 
 pragma solidity ^0.4.8;
 
-contract Medianizer is DSValue {
+contract Medianizer is DSMath {
+    bool    has;
+    bytes32 val;
+
     mapping (address => bool)    public tokas;  // Is ERC20 Token Approved
     mapping (bytes12 => address) public values;
     mapping (address => bytes12) public indexes;
@@ -58,11 +62,21 @@ contract Medianizer is DSValue {
     function setMax(uint256 maxr_) {
     	require(on);
     	require(msg.sender == own);
-    	DSValue(values[bytes12(1)]).setMax(maxr_);
-    	DSValue(values[bytes12(2)]).setMax(maxr_);
-    	DSValue(values[bytes12(3)]).setMax(maxr_);
-    	DSValue(values[bytes12(4)]).setMax(maxr_);
-    	DSValue(values[bytes12(5)]).setMax(maxr_);
+      Oracle(values[bytes12(1)]).setMax(maxr_);
+      Oracle(values[bytes12(2)]).setMax(maxr_);
+      Oracle(values[bytes12(3)]).setMax(maxr_);
+      Oracle(values[bytes12(4)]).setMax(maxr_);
+      Oracle(values[bytes12(5)]).setMax(maxr_);
+    }
+
+    function peek() constant returns (bytes32, bool) {
+        return (val,has);
+    }
+    
+    function read() constant returns (bytes32) {
+        var (wut, has) = peek();
+        assert(has);
+        return wut;
     }
 
     function push (uint256 amt, ERC20 tok) {
@@ -91,7 +105,7 @@ contract Medianizer is DSValue {
         uint96 ctr = 0;
         for (uint96 i = 1; i < uint96(next); i++) {
             if (values[bytes12(i)] != 0) {
-                var (wut, wuz) = DSValue(values[bytes12(i)]).peek();
+                var (wut, wuz) = Oracle(values[bytes12(i)]).peek();
                 if (wuz) {
                     if (ctr == 0 || wut >= wuts[ctr - 1]) {
                         wuts[ctr] = wut;

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -1,15 +1,15 @@
 pragma solidity >0.4.18;
 
 import "./DSMath.sol";
-import "./DSValue.sol";
+import "./ERC20.sol";
+import "./Medianizer.sol";
 
 contract Oracle is DSMath {
     uint32  constant public DELAY = 900; // 15 Minutes
     uint128 constant public prem = 1100000000000000000; // premium 1.1 (10%)
     uint128 constant public turn = 1010000000000000000; // minimum price change 1.01 (1%)
 
-    DSValue med;
-    DSValue medm;
+    Medianizer med;
     ERC20   tok;
 
     uint32 public zzz;
@@ -49,35 +49,6 @@ contract Oracle is DSMath {
     function bill() public view returns (uint256) {
         return pmt;
     }
-    
-    function pack(ERC20 tok_) {
-        pack(uint128(bill()), tok_);   
-    }
-    
-    function pack(uint128 pmt_, ERC20 tok_) { // payment
-        require(uint32(now) > lag);
-        pmt = pmt_;
-        dis = 0;
-        lag = uint32(now) + DELAY;
-        owed = msg.sender;
-        tok = tok_;
-        told = false;
-        posted = false;
-        call();
-        chec();
-    }
-    
-    function call()
-        internal
-    {
-        zzz = uint32(now + 43200);
-    }
-    
-    function chec()
-        internal
-    {
-        tell(uint128(medm.read()));
-    }
 
     function post(uint128 val_, uint32 zzz_) internal
     {
@@ -101,4 +72,6 @@ contract Oracle is DSMath {
             require(tok.transfer(owed, gain));
         }
     }
+
+    function setMax(uint256 maxr_) public;
 }

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -1,13 +1,12 @@
 pragma solidity >0.4.18;
 
 import "./ChainLink.sol";
-import "../DSValue.sol";
 
 contract BlockchainInfo is ChainLink {
     bytes32 constant UINT256_MUL_JOB = bytes32("9f0406209cf64acda32636018b33de11");
     bytes32 constant UINT256_MUL_JOB__LINK = bytes32("35e428271aad4506afc4f4089ce98f68");
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
         ChainLink(med_, link_, oracle_)
     {}

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -3,13 +3,12 @@ pragma solidity >0.4.18;
 import "./ChainlinkedTesting.sol";
 import "../Oracle.sol";
 import "../ERC20.sol";
-import "../DSValue.sol";
 
 contract ChainLink is ChainlinkClient, Oracle {
     ERC20 link;
     uint256 maxr; // Max reward
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
     {
         med = med_;

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -32,13 +32,9 @@ contract ChainLink is ChainlinkClient, Oracle {
         chec();
     }
 
-    function call() internal {
-        zzz = uint32(now + 43200);
-    }
+    function call() internal;
 
-    function chec() internal {
-        zzz = uint32(now + 43200);
-    }
+    function chec() internal;
 
     function cur(bytes32 _requestId, uint256 _price) // Currency
         public

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -1,12 +1,11 @@
 pragma solidity >0.4.18;
 
 import "./ChainLink.sol";
-import "../DSValue.sol";
 
 contract CoinMarketCap is ChainLink {
     bytes32 constant UINT256_MUL_JOB = bytes32("ce36a79ea04c4d3ca015d267784417bd");
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
         ChainLink(med_, link_, oracle_)
     {}

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -1,12 +1,11 @@
 pragma solidity >0.4.18;
 
 import "./ChainLink.sol";
-import "../DSValue.sol";
 
 contract CryptoCompare is ChainLink {
     bytes32 constant UINT256_MUL_JOB = bytes32("35e428271aad4506afc4f4089ce98f68");
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
         ChainLink(med_, link_, oracle_)
     {}

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -1,13 +1,12 @@
 pragma solidity >0.4.18;
 
 import "./ChainLink.sol";
-import "../DSValue.sol";
 
 contract Gemini is ChainLink {
     bytes32 constant UINT256_MUL_JOB = bytes32("9f0406209cf64acda32636018b33de11");
     bytes32 constant UINT256_MUL_JOB__LINK = bytes32("35e428271aad4506afc4f4089ce98f68");
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
         ChainLink(med_, link_, oracle_)
     {}

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -1,13 +1,12 @@
 pragma solidity >0.4.18;
 
 import "./ChainLink.sol";
-import "../DSValue.sol";
 
 contract SoChain is ChainLink {
     bytes32 constant UINT256_MUL_JOB = bytes32("9f0406209cf64acda32636018b33de11");
     bytes32 constant UINT256_MUL_JOB__LINK = bytes32("35e428271aad4506afc4f4089ce98f68");
 
-    constructor(DSValue med_, ERC20 link_, address oracle_)
+    constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
         ChainLink(med_, link_, oracle_)
     {}

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -3,7 +3,7 @@ pragma solidity >0.4.18;
 import "./Oraclize.sol";
 
 contract Bitstamp is Oraclize {
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
         Oraclize(med_, medm_, weth_)
     {}

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -3,7 +3,7 @@ pragma solidity >0.4.18;
 import "./Oraclize.sol";
 
 contract Coinbase is Oraclize {
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
         Oraclize(med_, medm_, weth_)
     {}

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -3,7 +3,7 @@ pragma solidity >0.4.18;
 import "./Oraclize.sol";
 
 contract Coinpaprika is Oraclize {
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
         Oraclize(med_, medm_, weth_)
     {}

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -3,7 +3,7 @@ pragma solidity >0.4.18;
 import "./Oraclize.sol";
 
 contract CryptoWatch is Oraclize {
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
         Oraclize(med_, medm_, weth_)
     {}

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -3,7 +3,7 @@ pragma solidity >0.4.18;
 import "./Oraclize.sol";
 
 contract Kraken is Oraclize {
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
         Oraclize(med_, medm_, weth_)
     {}

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -3,12 +3,12 @@ pragma solidity >0.4.18;
 import "./OraclizeAPITesting.sol";
 import "../Oracle.sol";
 import "../WETH.sol";
-import "../DSValue.sol";
 
 contract Oraclize is usingOraclize, Oracle {
     WETH weth;
+    Medianizer medm;
 
-    constructor(DSValue med_, DSValue medm_, WETH weth_)
+    constructor(Medianizer med_, Medianizer medm_, WETH weth_)
         public
     {
         med = med_;
@@ -42,10 +42,20 @@ contract Oraclize is usingOraclize, Oracle {
         call();
         chec();
     }
+
+    function call() internal;
+
+    function chec() internal {
+        tell(uint128(medm.read()));
+    }
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());
         uint128 res = uint128(parseInt(result, 18));
         post(res, uint32(now + 43200));
+    }
+
+    function setMax(uint256 maxr_) public {
+        require(msg.sender == address(med));
     }
 }


### PR DESCRIPTION
This PR improves oracle inheritance model. 

The inheritance model used by the oracle contracts makes the code hard to verify:

1. `setMax` is in `DSValue`, but the only thing that inherits from `DSValue` is `Medianizer`, and it overloads that. This is good because the implementation there is bizarre (just sets `has` to `true`).
2. The `Medianizer` casts `Oracle`s to `DSValue` even though they don’t inherit from that. This is to call `setMax`, which shouldn’t be in `DSValue` anyway, and `peek`, which could just be used from `Oracle` (the proper type).
3. `Oracle` has an implementation of `pack` that is never used (overloaded everywhere).
4. `Oracle` has `medm` and an implementation of `chec` that uses it even though these only apply to contracts that derive from `Oraclize` (so that code should go there). 
5. `Oracle` has a harmful implementation of `call` (one that extends the expiration of the existing value), but fortunately it's overridden in every actual oracle implementation.