### PR TITLE
Replace unnecessary low-level call with interface call

### DIFF
--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -55,7 +55,7 @@ contract Oracle is DSMath {
         if (val_ >= wmul(val, turn) || val_ <= wdiv(val, turn)) { dis = pmt; }
         val = val_;
         zzz = zzz_;
-        med.call(abi.encodeWithSignature("poke()"));
+        med.poke();
         posted = true;
         if (told) { ward(); }
     }


### PR DESCRIPTION
This PR removes necessary low level call `med.call(abi.encodeWithSignature("poke()"));` and instead replaces it with interface call `med.poke();`. 