### PR TITLE
Implement protection for oracle pack race condition

### DIFF
--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -10,18 +10,23 @@ contract Oracle is DSMath {
     uint128 constant public turn = 1010000000000000000; // minimum price change 1.01 (1%)
 
     Medianizer med;
-    ERC20   tok;
 
     uint32 public zzz;
     uint32 public lag;
-    address owed;                    // Address owed reward
     uint128 val;                     
     uint128 public lval;             // Link value
-    uint128 pmt;                     // Payment
-    uint128 dis;
     uint256 gain;
-    bool posted;                     // Currency price posted
-    bool told;                       // Payment currency price posted
+
+    mapping(bytes32 => Areq) areqs;
+
+    struct Areq {
+        address owed;
+        uint128 pmt;
+        uint128 dis;
+        ERC20 tok;
+        bool posted;
+        bool told;
+    }
 
     function peek() public view
         returns (bytes32,bool)
@@ -40,30 +45,27 @@ contract Oracle is DSMath {
         require(tok_.transferFrom(msg.sender, address(this), uint256(amt)));
     }
     
-    function bill() public view returns (uint256) {
-        return pmt;
-    }
-
-    function post(uint128 val_, uint32 zzz_) internal
+    function post(bytes32 queryId, uint128 val_, uint32 zzz_) internal
     {
-        if (val_ >= wmul(val, turn) || val_ <= wdiv(val, turn)) { dis = pmt; }
+        areqs[queryId].dis = 0;
+        if (val_ >= wmul(val, turn) || val_ <= wdiv(val, turn)) { areqs[queryId].dis = areqs[queryId].pmt; }
         val = val_;
         zzz = zzz_;
         med.poke();
-        posted = true;
-        if (told) { ward(); }
+        areqs[queryId].posted = true;
+        if (areqs[queryId].told) { ward(queryId); }
     }
 
-    function tell(uint128 lval_) internal {
+    function tell(bytes32 queryId, uint128 lval_) internal {
         lval = lval_;
-        told = true;
-        if (posted) { ward(); }
+        areqs[queryId].told = true;
+        if (areqs[queryId].posted) { ward(queryId); }
     }
 
-    function ward() internal { // Reward
-        gain = wmul(wmul(lval, dis), prem);
-        if (tok.balanceOf(address(this)) >= gain && dis > 0) {
-            require(tok.transfer(owed, gain));
+    function ward(bytes32 queryId) internal { // Reward
+        gain = wmul(wmul(lval, areqs[queryId].dis), prem);
+        if (areqs[queryId].tok.balanceOf(address(this)) >= gain && areqs[queryId].dis > 0) {
+            require(areqs[queryId].tok.transfer(areqs[queryId].owed, gain));
         }
     }
 

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -67,6 +67,7 @@ contract Oracle is DSMath {
         if (areqs[queryId].tok.balanceOf(address(this)) >= gain && areqs[queryId].dis > 0) {
             require(areqs[queryId].tok.transfer(areqs[queryId].owed, gain));
         }
+        delete(areqs[queryId]);
     }
 
     function setMax(uint256 maxr_) public;

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -11,21 +11,23 @@ contract BlockchainInfo is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call() internal {
+    function call(uint128 pmt) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://blockchain.info/ticker?currency=USD");
         req.add("path", "USD.last");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(pmt, 2));
     }
 
-    function chec() internal {
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        linkrs[linkrId] = queryId;
+        return linkrId;
     }
 }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -8,6 +8,10 @@ contract ChainLink is ChainlinkClient, Oracle {
     ERC20 link;
     uint256 maxr; // Max reward
 
+    bytes32 public lastQueryId;
+
+    mapping(bytes32 => bytes32) linkrs;
+
     constructor(Medianizer med_, ERC20 link_, address oracle_)
         public
     {
@@ -15,45 +19,48 @@ contract ChainLink is ChainlinkClient, Oracle {
         link = link_;
         setChainlinkToken(address(link_));
         setChainlinkOracle(oracle_);
-        pmt = uint128(2 * LINK);
+        areqs[lastQueryId].pmt = uint128(2 * LINK);
+    }
+
+    function bill() public view returns (uint256) {
+        return areqs[lastQueryId].pmt;
     }
 
     function pack(uint128 pmt_, ERC20 tok_) { // payment
         require(uint32(now) > lag);
         require(link.transferFrom(msg.sender, address(this), uint(pmt_)));
-        pmt = pmt_;
-        dis = 0;
+        bytes32 queryId = call(pmt_);
+        lastQueryId = queryId;
+        bytes32 linkrId = chec(pmt_, queryId);
+        linkrs[linkrId] = queryId;
+        areqs[queryId].owed = msg.sender;
+        areqs[queryId].pmt  = pmt_;
+        areqs[queryId].tok  = tok_;
         lag = uint32(now) + DELAY;
-        owed = msg.sender;
-        tok = tok_;
-        told = false;
-        posted = false;
-        call();
-        chec();
     }
 
-    function call() internal;
+    function call(uint128 pmt) internal returns (bytes32);
 
-    function chec() internal;
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32);
 
     function cur(bytes32 _requestId, uint256 _price) // Currency
         public
         recordChainlinkFulfillment(_requestId)
     {
-        post(uint128(_price), uint32(now + 43200));
+        post(_requestId, uint128(_price), uint32(now + 43200));
     }
     
     function sup(bytes32 _requestId, uint256 _price) // Supply Currency
         public
         recordChainlinkFulfillment(_requestId)
     {
-        tell(uint128(_price));
+        tell(linkrs[_requestId], uint128(_price));
     }
 
-    function ward() internal { // Reward
-        gain = wmul(wmul(lval, dis), prem);
-        if (tok.balanceOf(address(this)) >= min(maxr, gain) && dis > 0) {
-            require(tok.transfer(owed, min(maxr, gain)));
+    function ward(bytes32 queryId) internal { // Reward
+        gain = wmul(wmul(lval, areqs[queryId].dis), prem);
+        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxr, gain) && areqs[queryId].dis > 0) {
+            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxr, gain)));
         }
     }
 

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -10,7 +10,7 @@ contract CoinMarketCap is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call() internal {
+    function call(uint128 pmt) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("sym", "BTC");
         req.add("convert", "USD");
@@ -22,10 +22,10 @@ contract CoinMarketCap is ChainLink {
         path[4] = "price";
         req.addStringArray("copyPath", path);
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(pmt, 2));
     }
 
-    function chec() internal {
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("sym", "LINK");
         req.add("convert", "USD");
@@ -37,6 +37,8 @@ contract CoinMarketCap is ChainLink {
         path[4] = "price";
         req.addStringArray("copyPath", path);
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        linkrs[linkrId] = queryId;
+        return linkrId;
     }
 }

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -10,23 +10,25 @@ contract CryptoCompare is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call() internal {
+    function call(uint128 pmt) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("endpoint", "price");
         req.add("fsym", "BTC");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(pmt, 2));
     }
 
-    function chec() internal {
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        linkrs[linkrId] = queryId;
+        return linkrId;
     }
 }

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -11,21 +11,23 @@ contract Gemini is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call() internal {
+    function call(uint128 pmt) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://api.gemini.com/v1/pubticker/btcusd");
         req.add("path", "last");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(pmt, 2));
     }
 
-    function chec() internal {
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        linkrs[linkrId] = queryId;
+        return linkrId;
     }
 }

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -11,21 +11,23 @@ contract SoChain is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call() internal {
+    function call(uint128 pmt) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://chain.so/api/v2/get_info/BTC");
         req.add("path", "data.price");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(pmt, 2));
     }
 
-    function chec() internal {
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        linkrs[linkrId] = queryId;
+        return linkrId;
     }
 }

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -8,11 +8,11 @@ contract Bitstamp is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call()
-        internal
+    function call(uint128 pmt)
+        internal returns (bytes32 queryId)
     {
         weth.withdraw(pmt);
         require(oraclize_getPrice("URL") <= address(this).balance);
-        oraclize_query("URL", "json(https://www.bitstamp.net/api/v2/ticker/btcusd).last");
+        queryId = oraclize_query("URL", "json(https://www.bitstamp.net/api/v2/ticker/btcusd).last");
     }
 }

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -8,11 +8,11 @@ contract Coinbase is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call()
-        internal
+    function call(uint128 pmt)
+        internal returns (bytes32 queryId)
     {
         weth.withdraw(pmt);
         require(oraclize_getPrice("URL") <= address(this).balance);
-        oraclize_query("URL", "json(https://api.pro.coinbase.com/products/BTC-USD/ticker).price");
+        queryId = oraclize_query("URL", "json(https://api.pro.coinbase.com/products/BTC-USD/ticker).price");
     }
 }

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -8,11 +8,11 @@ contract Coinpaprika is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call()
-        internal
+    function call(uint128 pmt)
+        internal returns (bytes32 queryId)
     {
         weth.withdraw(pmt);
         require(oraclize_getPrice("URL") <= address(this).balance);
-        oraclize_query("URL", "json(https://api.coinpaprika.com/v1/tickers/btc-bitcoin).quotes.USD.price");
+        queryId = oraclize_query("URL", "json(https://api.coinpaprika.com/v1/tickers/btc-bitcoin).quotes.USD.price");
     }
 }

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -8,11 +8,11 @@ contract CryptoWatch is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call()
-        internal
+    function call(uint128 pmt)
+        internal returns (bytes32 queryId)
     {
         weth.withdraw(pmt);
         require(oraclize_getPrice("URL") <= address(this).balance);
-        oraclize_query("URL", "json(https://api.cryptowat.ch/markets/coinbase-pro/btcusd/price).result.price");
+        queryId = oraclize_query("URL", "json(https://api.cryptowat.ch/markets/coinbase-pro/btcusd/price).result.price");
     }
 }

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -8,11 +8,11 @@ contract Kraken is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call()
-        internal
+    function call(uint128 pmt)
+        internal returns (bytes32 queryId)
     {
         weth.withdraw(pmt);
         require(oraclize_getPrice("URL") <= address(this).balance);
-        oraclize_query("URL", "json(https://api.kraken.com/0/public/Ticker?pair=XBTUSD).result.XXBTZUSD.c.0");
+        queryId = oraclize_query("URL", "json(https://api.kraken.com/0/public/Ticker?pair=XBTUSD).result.XXBTZUSD.c.0");
     }
 }

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -32,7 +32,7 @@ contract Oraclize is usingOraclize, Oracle {
         require(pmt_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
         bytes32 queryId = call(pmt_);
-        chec(pmt_, queryId);
+        tell(queryId, uint128(medm.read()));
         areqs[queryId].owed = msg.sender;
         areqs[queryId].pmt  = pmt_;
         areqs[queryId].tok  = tok_;
@@ -40,10 +40,6 @@ contract Oraclize is usingOraclize, Oracle {
     }
 
     function call(uint128 pmt) internal returns (bytes32);
-
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
-        tell(queryId, uint128(medm.read()));
-    }
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -43,6 +43,7 @@ contract Oraclize is usingOraclize, Oracle {
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());
+        require(areqs[myid].owed != address(0));
         uint128 res = uint128(parseInt(result, 18));
         post(myid, res, uint32(now + 43200));
     }

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -14,7 +14,6 @@ contract Oraclize is usingOraclize, Oracle {
         med = med_;
         medm = medm_;
         weth = weth_;
-        pmt = uint128(bill());
         oraclize_setProof(proofType_Android | proofStorage_IPFS);
     }
 
@@ -32,27 +31,24 @@ contract Oraclize is usingOraclize, Oracle {
         require(uint32(now) > lag);
         require(pmt_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
-        pmt = pmt_;
-        dis = 0;
+        bytes32 queryId = call(pmt_);
+        chec(pmt_, queryId);
+        areqs[queryId].owed = msg.sender;
+        areqs[queryId].pmt  = pmt_;
+        areqs[queryId].tok  = tok_;
         lag = uint32(now) + DELAY;
-        owed = msg.sender;
-        tok = tok_;
-        told = false;
-        posted = false;
-        call();
-        chec();
     }
 
-    function call() internal;
+    function call(uint128 pmt) internal returns (bytes32);
 
-    function chec() internal {
-        tell(uint128(medm.read()));
+    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+        tell(queryId, uint128(medm.read()));
     }
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());
         uint128 res = uint128(parseInt(result, 18));
-        post(res, uint32(now + 43200));
+        post(myid, res, uint32(now + 43200));
     }
 
     function setMax(uint256 maxr_) public {

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -96,13 +96,13 @@ contract("Chainlink", accounts => {
 
       await this.med.setMax(toWei('10', 'ether'), { from: own })
 
-      await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
+      const tx = await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
 
       const balBefore = await this.token.balanceOf.call(updater)
 
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12783.31', 'ether'), { from: chainlink })
+      await this.blockchainInfo.cur(tx.logs[0].args.id, toWei('12783.31', 'ether'), { from: chainlink })
 
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('5.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.sup(tx.logs[1].args.id, toWei('5.19', 'ether'), { from: chainlink })
 
       const balAfter = await this.token.balanceOf.call(updater)
 

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -27,7 +27,7 @@ var MakerMedianizer = artifacts.require("./DSValue.sol");
 const utils = require('./helpers/Utils.js');
 
 const { rateToSec, numToBytes32 } = utils;
-const { toWei, fromWei, asciiToHex, hexToNumberString, hexToNumber, padLeft, numberToHex } = web3.utils;
+const { toWei, fromWei, asciiToHex, hexToNumberString, hexToNumber, padLeft, padRight, numberToHex } = web3.utils;
 
 const API_ENDPOINT_COIN = "https://atomicloans.io/marketcap/api/v1/"
 const BTC_TO_SAT = 10**8
@@ -107,7 +107,7 @@ contract("Medianizer", accounts => {
       await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.kraken.__callback(asciiToHex("1"), '12529.71')
+      await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       const peek = await this.med.peek.call()
       assert.equal(peek[1], false)
@@ -129,10 +129,10 @@ contract("Medianizer", accounts => {
       await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.bitstamp.__callback(asciiToHex("1"), '12529.71')
+      await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
       await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinbase.__callback(asciiToHex("1"), '12529.71')
+      await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
       const read = await this.med.read.call()
 
@@ -163,19 +163,19 @@ contract("Medianizer", accounts => {
       await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.bitstamp.__callback(asciiToHex("1"), '12529.71')
+      await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
       await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinbase.__callback(asciiToHex("1"), '12529.71')
+      await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
       await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.cryptoWatch.__callback(asciiToHex("1"), '12529.71')
+      await this.cryptoWatch.__callback(padRight('0x', 64), '12529.71')
 
       await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinpaprika.__callback(asciiToHex("1"), '12529.71')
+      await this.coinpaprika.__callback(padRight('0x', 64), '12529.71')
 
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.kraken.__callback(asciiToHex("1"), '12529.71')
+      await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       const read = await this.med.read.call()
 
@@ -206,19 +206,19 @@ contract("Medianizer", accounts => {
       await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.bitstamp.__callback(asciiToHex("1"), '17000')
+      await this.bitstamp.__callback(padRight('0x', 64), '17000')
 
       await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinbase.__callback(asciiToHex("1"), '18000')
+      await this.coinbase.__callback(padRight('0x', 64), '18000')
 
       await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.cryptoWatch.__callback(asciiToHex("1"), '19000')
+      await this.cryptoWatch.__callback(padRight('0x', 64), '19000')
 
       await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinpaprika.__callback(asciiToHex("1"), '20000')
+      await this.coinpaprika.__callback(padRight('0x', 64), '20000')
 
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.kraken.__callback(asciiToHex("1"), '21000')
+      await this.kraken.__callback(padRight('0x', 64), '21000')
 
       const read = await this.med.read.call()
 
@@ -249,19 +249,19 @@ contract("Medianizer", accounts => {
       await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.bitstamp.__callback(asciiToHex("1"), '12529.71')
+      await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
       await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinbase.__callback(asciiToHex("1"), '12529.71')
+      await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
       await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.cryptoWatch.__callback(asciiToHex("1"), '12529.71')
+      await this.cryptoWatch.__callback(padRight('0x', 64), '12529.71')
 
       await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.coinpaprika.__callback(asciiToHex("1"), '12529.71')
+      await this.coinpaprika.__callback(padRight('0x', 64), '12529.71')
 
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
-      await this.kraken.__callback(asciiToHex("1"), '12529.71')
+      await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       await time.increase(43300)
 

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -72,7 +72,7 @@ contract("Oraclize", accounts => {
 
       await this.coinbase.pack(this.bill, this.token.address, { from: updater })
 
-      await this.coinbase.__callback(asciiToHex("1"), "12529.71")
+      await this.coinbase.__callback(padRight('0x', 64), "12529.71")
 
       await shouldFail.reverting(this.coinbase.pack(this.bill, this.token.address), { from: updater })
     })
@@ -82,7 +82,7 @@ contract("Oraclize", accounts => {
 
       await this.coinbase.pack(this.bill, this.token.address, { from: updater })
 
-      await this.coinbase.__callback(asciiToHex("1"), '12656.71')
+      await this.coinbase.__callback(padRight('0x', 64), '12656.71')
 
       const read = await this.coinbase.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -21,7 +21,7 @@ var MakerMedianizer = artifacts.require("./DSValue.sol");
 const utils = require('./helpers/Utils.js');
 
 const { rateToSec, numToBytes32 } = utils;
-const { toWei, fromWei, asciiToHex, hexToNumberString, numberToHex, padLeft } = web3.utils;
+const { toWei, fromWei, asciiToHex, hexToNumberString, numberToHex, padLeft, padRight } = web3.utils;
 
 const API_ENDPOINT_COIN = "https://atomicloans.io/marketcap/api/v1/"
 const BTC_TO_SAT = 10**8
@@ -102,7 +102,7 @@ contract("Oraclize", accounts => {
 
       const balBefore = await this.token.balanceOf.call(updater)
 
-      await this.coinbase.__callback(asciiToHex("1"), '12784.2771')
+      await this.coinbase.__callback(padRight('0x', 64), '12784.2771')
 
       const balAfter = await this.token.balanceOf.call(updater)
 
@@ -116,7 +116,7 @@ contract("Oraclize", accounts => {
 
       const balBefore = await this.token.balanceOf.call(updater)
 
-      await this.coinbase.__callback(asciiToHex("1"), '12913.4128')
+      await this.coinbase.__callback(padRight('0x', 64), '12913.4128')
 
       const balAfter = await this.token.balanceOf.call(updater)
 
@@ -128,7 +128,7 @@ contract("Oraclize", accounts => {
 
       const balBefore2 = await this.token.balanceOf.call(updater)
 
-      await this.coinbase.__callback(asciiToHex("1"), '12913.4128')
+      await this.coinbase.__callback(padRight('0x', 64), '12913.4128')
 
       const balAfter2 = await this.token.balanceOf.call(updater)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,15 @@ bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
 
-bignumber.js@^8.0.2, bignumber.js@^8.1.1:
+bignumber.js@^8.0.2:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
   integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 binary-extensions@^1.0.0:
   version "1.13.0"


### PR DESCRIPTION
This PR implements protection for oracle pack race condition

The oracles currently use "global" state variables to keep track of the last person to call pack successfully, how much they paid, and what token they would like to be rewarded in. There's a potential race condition here:

Alice calls `pack`, which triggers an asynchronous request to Oraclize for data.
Bob calls `pack`.
Oraclize calls `__callback` for Alice's request, but Bob is paid the reward.
Oraclize cals `__callback` for Bob's request, and Bob is paid again.
This risk is mitigated by the use of a cool down period. The lag state variable is used to keep track of the next valid time a call to `pack` can be made, and it is intended to be sufficiently long that a request to Oraclize or Chainlink will complete before a subsequent request can be made.

Currently there is a cool down period of 15 minutes. However, no cool down period is sufficiently long to handle failures that may occur (e.g. Oraclize having downtime).

A better approach might be to keep track of this data per request and reward accordingly no matter when the results arrive. Doing this also makes it easy to ensure the same request isn't fulfilled twice.