### PR TITLE
Change all oracle contracts to use specific solidity version

### DIFF
--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 /*
 Begin solidity-cborutils

--- a/contracts/DSMath.sol
+++ b/contracts/DSMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 contract DSMath {
     

--- a/contracts/DSValue.sol
+++ b/contracts/DSValue.sol
@@ -1,7 +1,7 @@
 import "./DSMath.sol";
 import "./ERC20.sol";
 
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.26;
 
 contract DSValue is DSMath {
     bool    has;

--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 
 /**

--- a/contracts/ExampleDaiCoin.sol
+++ b/contracts/ExampleDaiCoin.sol
@@ -1,6 +1,6 @@
 import 'chainlink/node_modules/openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 contract ExampleDaiCoin is StandardToken {
   string public name = "ExampleDAICoin"; 

--- a/contracts/ExampleLinkCoin.sol
+++ b/contracts/ExampleLinkCoin.sol
@@ -1,6 +1,6 @@
 import 'chainlink/node_modules/openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 contract ExampleLinkCoin is StandardToken {
   string public name = "ExampleLinkCoin"; 

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -2,7 +2,7 @@ import "./ERC20.sol";
 import "./Oracle.sol";
 import "./DSMath.sol";
 
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.26;
 
 contract Medianizer is DSMath {
     bool    has;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 contract Migrations {
   address public owner;

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./DSMath.sol";
 import "./ERC20.sol";

--- a/contracts/WETH.sol
+++ b/contracts/WETH.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 import './ERC20.sol';
 

--- a/contracts/WETH9.sol
+++ b/contracts/WETH9.sol
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 contract WETH9 {
     string public name     = "Wrapped Ether";

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainLink.sol";
 

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainlinkedTesting.sol";
 import "../Oracle.sol";

--- a/contracts/chainlink/Chainlinked.sol
+++ b/contracts/chainlink/Chainlinked.sol
@@ -1,6 +1,6 @@
 // File: contracts/Chainlink.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 import "../Buffer.sol";
 
@@ -129,7 +129,7 @@ library Chainlink {
 
 // File: contracts/ENSResolver.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 contract ENSResolver {
   function addr(bytes32 node) public view returns (address);
@@ -137,7 +137,7 @@ contract ENSResolver {
 
 // File: contracts/interfaces/ENSInterface.sol
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 interface ENSInterface {
 
@@ -166,7 +166,7 @@ interface ENSInterface {
 
 // File: contracts/interfaces/LinkTokenInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface LinkTokenInterface {
   function allowance(address owner, address spender) external returns (bool success);
@@ -185,7 +185,7 @@ interface LinkTokenInterface {
 
 // File: contracts/interfaces/ChainlinkRequestInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface ChainlinkRequestInterface {
   function oracleRequest(
@@ -209,7 +209,7 @@ interface ChainlinkRequestInterface {
 
 // File: contracts/interfaces/PointerInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface PointerInterface {
   function getAddress() external view returns (address);
@@ -217,7 +217,7 @@ interface PointerInterface {
 
 // File: openzeppelin-solidity/contracts/math/SafeMath.sol
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 
 /**
@@ -272,7 +272,7 @@ library SafeMath {
 
 // File: contracts/ChainlinkClient.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 
 
@@ -536,7 +536,7 @@ contract ChainlinkClient {
 
 // File: openzeppelin-solidity/contracts/ownership/Ownable.sol
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 
 /**

--- a/contracts/chainlink/ChainlinkedTesting.sol
+++ b/contracts/chainlink/ChainlinkedTesting.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 import "../Buffer.sol";
 
@@ -126,7 +126,7 @@ library Chainlink {
 
 // File: contracts/ENSResolver.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 contract ENSResolver {
   function addr(bytes32 node) public view returns (address);
@@ -134,7 +134,7 @@ contract ENSResolver {
 
 // File: contracts/interfaces/ENSInterface.sol
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.26;
 
 interface ENSInterface {
 
@@ -163,7 +163,7 @@ interface ENSInterface {
 
 // File: contracts/interfaces/LinkTokenInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface LinkTokenInterface {
   function allowance(address owner, address spender) external returns (bool success);
@@ -182,7 +182,7 @@ interface LinkTokenInterface {
 
 // File: contracts/interfaces/ChainlinkRequestInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface ChainlinkRequestInterface {
   function oracleRequest(
@@ -206,7 +206,7 @@ interface ChainlinkRequestInterface {
 
 // File: contracts/interfaces/PointerInterface.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 interface PointerInterface {
   function getAddress() external view returns (address);
@@ -214,7 +214,7 @@ interface PointerInterface {
 
 // File: openzeppelin-solidity/contracts/math/SafeMath.sol
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 
 /**
@@ -269,7 +269,7 @@ library SafeMath {
 
 // File: contracts/ChainlinkClient.sol
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.26;
 
 
 
@@ -533,7 +533,7 @@ contract ChainlinkClient {
 
 // File: openzeppelin-solidity/contracts/ownership/Ownable.sol
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 
 /**

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainLink.sol";
 

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainLink.sol";
 

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainLink.sol";
 

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./ChainLink.sol";
 

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./Oraclize.sol";
 

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./Oraclize.sol";
 

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./Oraclize.sol";
 

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./Oraclize.sol";
 

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./Oraclize.sol";
 

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -1,4 +1,4 @@
-pragma solidity >0.4.18;
+pragma solidity ^0.4.26;
 
 import "./OraclizeAPITesting.sol";
 import "../Oracle.sol";

--- a/contracts/oraclize/OraclizeAPI.sol
+++ b/contracts/oraclize/OraclizeAPI.sol
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 // This api is currently targeted at 0.4.22 to 0.4.25 (stable builds), please import oraclizeAPI_pre0.4.sol or oraclizeAPI_0.4 where necessary
 
-pragma solidity ^0.4.24;// Incompatible compiler version... please select one stated within pragma solidity or use different oraclizeAPI version
+pragma solidity ^0.4.26; // Incompatible compiler version... please select one stated within pragma solidity or use different oraclizeAPI version
 
 import "../Buffer.sol";
 

--- a/contracts/oraclize/OraclizeAPITesting.sol
+++ b/contracts/oraclize/OraclizeAPITesting.sol
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 // This api is currently targeted at 0.4.22 to 0.4.25 (stable builds), please import oraclizeAPI_pre0.4.sol or oraclizeAPI_0.4 where necessary
 
-pragma solidity ^0.4.24; // Incompatible compiler version... please select one stated within pragma solidity or use different oraclizeAPI version
+pragma solidity ^0.4.26; // Incompatible compiler version... please select one stated within pragma solidity or use different oraclizeAPI version
 
 import "../Buffer.sol";
 

--- a/truffle.js
+++ b/truffle.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.4.24",
+      version: "0.4.26",
       settings: {
         optimizer: {
           enabled: false,


### PR DESCRIPTION
### Description

This PR ensures all oracle contracts use the same solidity version. 

### Submission Checklist :pencil:

- [x] Ensure all oracle contracts use `^0.4.26`
- [x] Update Truffle config to use `solc` `0.4.26`
