### PR TITLE
Remove unneeded Oracle.eval

### DIFF
--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -16,7 +16,7 @@ contract Oracle is DSMath {
     uint32 public lag;
     address owed;                    // Address owed reward
     uint128 val;                     
-    uint128 lval;                    // Link value
+    uint128 public lval;             // Link value
     uint128 pmt;                     // Payment
     uint128 dis;
     uint256 gain;
@@ -34,12 +34,6 @@ contract Oracle is DSMath {
     {
         assert(now < zzz);
         return bytes32(uint(val));
-    }
-    
-    function eval() public view
-        returns (bytes32)
-    {
-        return bytes32(uint(lval));
     }
 
     function push(uint128 amt, ERC20 tok_) public {

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -83,8 +83,8 @@ contract("Chainlink", accounts => {
       const read = await this.blockchainInfo.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))
 
-      const eval = await this.blockchainInfo.eval.call()
-      assert.equal(toWei('3.19', 'ether'), hexToNumberString(eval))
+      const lval = await this.blockchainInfo.lval.call()
+      assert.equal(toWei('3.19', 'ether'), lval)
 
       const peek = await this.blockchainInfo.peek.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(peek[0]))

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -87,8 +87,8 @@ contract("Oraclize", accounts => {
       const read = await this.coinbase.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))
 
-      const eval = await this.coinbase.eval.call()
-      assert.equal(toWei('303.79', 'ether'), hexToNumberString(eval))
+      const lval = await this.coinbase.lval.call()
+      assert.equal(toWei('303.79', 'ether'), lval)
 
       const peek = await this.coinbase.peek.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(peek[0]))


### PR DESCRIPTION
### Description

This PR removes unnecessary `Oracle.eval` and makes `lval` public instead. 

### Submission Checklist :pencil:

- [x] Remove unnecessary `Oracle.eval`
- [x] Make `lval` public
