### PR TITLE
Replace constant functions with pure or view

### DIFF
--- a/contracts/DSMath.sol
+++ b/contracts/DSMath.sol
@@ -6,27 +6,27 @@ contract DSMath {
     standard uint256 functions
      */
 
-    function add(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function add(uint256 x, uint256 y) pure internal returns (uint256 z) {
         assert((z = x + y) >= x);
     }
 
-    function sub(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function sub(uint256 x, uint256 y) pure internal returns (uint256 z) {
         assert((z = x - y) <= x);
     }
 
-    function mul(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function mul(uint256 x, uint256 y) pure internal returns (uint256 z) {
         assert((z = x * y) >= x);
     }
     
-    function div(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function div(uint256 x, uint256 y) pure internal returns (uint256 z) {
         require(y > 0);
         z = x / y;
     }
     
-    function min(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function min(uint256 x, uint256 y) pure internal returns (uint256 z) {
         return x <= y ? x : y;
     }
-    function max(uint256 x, uint256 y) constant internal returns (uint256 z) {
+    function max(uint256 x, uint256 y) pure internal returns (uint256 z) {
         return x >= y ? x : y;
     }
 
@@ -35,26 +35,26 @@ contract DSMath {
      */
 
 
-    function hadd(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hadd(uint128 x, uint128 y) pure internal returns (uint128 z) {
         assert((z = x + y) >= x);
     }
 
-    function hsub(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hsub(uint128 x, uint128 y) pure internal returns (uint128 z) {
         assert((z = x - y) <= x);
     }
 
-    function hmul(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hmul(uint128 x, uint128 y) pure internal returns (uint128 z) {
         assert((z = x * y) >= x);
     }
 
-    function hdiv(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hdiv(uint128 x, uint128 y) pure internal returns (uint128 z) {
         z = x / y;
     }
 
-    function hmin(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hmin(uint128 x, uint128 y) pure internal returns (uint128 z) {
         return x <= y ? x : y;
     }
-    function hmax(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function hmax(uint128 x, uint128 y) pure internal returns (uint128 z) {
         return x >= y ? x : y;
     }
 
@@ -63,10 +63,10 @@ contract DSMath {
     int256 functions
      */
 
-    function imin(int256 x, int256 y) constant internal returns (int256 z) {
+    function imin(int256 x, int256 y) pure internal returns (int256 z) {
         return x <= y ? x : y;
     }
-    function imax(int256 x, int256 y) constant internal returns (int256 z) {
+    function imax(int256 x, int256 y) pure internal returns (int256 z) {
         return x >= y ? x : y;
     }
 
@@ -76,26 +76,26 @@ contract DSMath {
 
     uint128 constant WAD = 10 ** 18;
 
-    function wadd(uint128 x, uint128 y) constant internal returns (uint128) {
+    function wadd(uint128 x, uint128 y) pure internal returns (uint128) {
         return hadd(x, y);
     }
 
-    function wsub(uint128 x, uint128 y) constant internal returns (uint128) {
+    function wsub(uint128 x, uint128 y) pure internal returns (uint128) {
         return hsub(x, y);
     }
 
-    function wmul(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function wmul(uint128 x, uint128 y) view internal returns (uint128 z) {
         z = cast((uint256(x) * y + WAD / 2) / WAD);
     }
 
-    function wdiv(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function wdiv(uint128 x, uint128 y) view internal returns (uint128 z) {
         z = cast((uint256(x) * WAD + y / 2) / y);
     }
 
-    function wmin(uint128 x, uint128 y) constant internal returns (uint128) {
+    function wmin(uint128 x, uint128 y) pure internal returns (uint128) {
         return hmin(x, y);
     }
-    function wmax(uint128 x, uint128 y) constant internal returns (uint128) {
+    function wmax(uint128 x, uint128 y) pure internal returns (uint128) {
         return hmax(x, y);
     }
 
@@ -105,23 +105,23 @@ contract DSMath {
 
     uint128 constant RAY = 10 ** 27;
 
-    function radd(uint128 x, uint128 y) constant internal returns (uint128) {
+    function radd(uint128 x, uint128 y) pure internal returns (uint128) {
         return hadd(x, y);
     }
 
-    function rsub(uint128 x, uint128 y) constant internal returns (uint128) {
+    function rsub(uint128 x, uint128 y) pure internal returns (uint128) {
         return hsub(x, y);
     }
 
-    function rmul(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function rmul(uint128 x, uint128 y) view internal returns (uint128 z) {
         z = cast((uint256(x) * y + RAY / 2) / RAY);
     }
 
-    function rdiv(uint128 x, uint128 y) constant internal returns (uint128 z) {
+    function rdiv(uint128 x, uint128 y) view internal returns (uint128 z) {
         z = cast((uint256(x) * RAY + y / 2) / y);
     }
 
-    function rpow(uint128 x, uint64 n) constant internal returns (uint128 z) {
+    function rpow(uint128 x, uint64 n) view internal returns (uint128 z) {
         // This famous algorithm is called "exponentiation by squaring"
         // and calculates x^n with x as fixed-point and n as regular unsigned.
         //
@@ -148,14 +148,14 @@ contract DSMath {
         }
     }
 
-    function rmin(uint128 x, uint128 y) constant internal returns (uint128) {
+    function rmin(uint128 x, uint128 y) pure internal returns (uint128) {
         return hmin(x, y);
     }
-    function rmax(uint128 x, uint128 y) constant internal returns (uint128) {
+    function rmax(uint128 x, uint128 y) pure internal returns (uint128) {
         return hmax(x, y);
     }
 
-    function cast(uint256 x) constant internal returns (uint128 z) {
+    function cast(uint256 x) pure internal returns (uint128 z) {
         assert((z = uint128(x)) == x);
     }
 

--- a/contracts/DSValue.sol
+++ b/contracts/DSValue.sol
@@ -6,11 +6,11 @@ pragma solidity ^0.4.8;
 contract DSValue is DSMath {
     bool    has;
     bytes32 val;
-    function peek() constant returns (bytes32, bool) {
+    function peek() public view returns (bytes32, bool) {
         return (val,has);
     }
     
-    function read() constant returns (bytes32) {
+    function read() public returns (bytes32) {
         var (wut, has) = peek();
         assert(has);
         return wut;

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -74,11 +74,11 @@ contract Medianizer is DSMath {
       Oracle(values[bytes12(10)]).setMax(maxr_);
     }
 
-    function peek() constant returns (bytes32, bool) {
+    function peek() public view returns (bytes32, bool) {
         return (val,has);
     }
 
-    function read() constant returns (bytes32) {
+    function read() public returns (bytes32) {
         var (wut, has) = peek();
         assert(has);
         return wut;
@@ -105,7 +105,7 @@ contract Medianizer is DSMath {
         (val, has) = compute();
     }
 
-    function compute() constant returns (bytes32, bool) {
+    function compute() public returns (bytes32, bool) {
         bytes32[] memory wuts = new bytes32[](uint96(next) - 1);
         uint96 ctr = 0;
         for (uint96 i = 1; i < uint96(next); i++) {

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -134,7 +134,7 @@ contract("Medianizer", accounts => {
       await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinbase.__callback(asciiToHex("1"), '12529.71')
 
-      const read = await this.med.read()
+      const read = await this.med.read.call()
 
       assert.equal(read, padLeft(numberToHex(toWei('12529.71', 'ether')), 64))
     })
@@ -177,7 +177,7 @@ contract("Medianizer", accounts => {
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(asciiToHex("1"), '12529.71')
 
-      const read = await this.med.read()
+      const read = await this.med.read.call()
 
       assert.equal(read, padLeft(numberToHex(toWei('12529.71', 'ether')), 64))
     })
@@ -220,7 +220,7 @@ contract("Medianizer", accounts => {
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(asciiToHex("1"), '21000')
 
-      const read = await this.med.read()
+      const read = await this.med.read.call()
 
       assert.equal(read, padLeft(numberToHex(toWei('16500', 'ether')), 64))
     })


### PR DESCRIPTION
### Description

This PR replaces `constant` functions with `pure` or `view`. This is more in line with current solidity standard, and will help with upgrading the contracts later on to `0.5.0`. 

### Submission Checklist :pencil:

- [x] Replace `constant` functions in `DSMath.sol` with `pure` or `view`
- [x] Replace `constant` functions in `DSValue.sol` with `pure` or `view`
- [x] Replace `constant` functions in `Medianizer.sol` with `pure` or `view`
