### PR TITLE
Exclude oraclize and chainlink from coveralls report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+coverage.json

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,12 @@
+module.exports = {
+  skipFiles: [
+    'DSMath.sol',
+    'Buffer.sol',
+    'WETH9.sol',
+    'DSValue.sol',
+    'chainlink/Chainlinked.sol',
+    'chainlink/ChainlinkedTesting.sol',
+    'oraclize/OraclizeAPI.sol',
+    'oraclize/OraclizeAPITesting.sol'
+  ]
+};


### PR DESCRIPTION
### Description

This PR excludes `Chainlinked.sol`, `ChainlinkedTesting.sol`, `OraclizeAPITesting.sol` and `OraclizeAPI.sol` from coveralls since test coverage for these files are covered by Oraclize and Chainlink. 

### Submission Checklist :pencil:

- [x] Exclude `Chainlinked.sol`, `ChainlinkedTesting.sol`, `OraclizeAPITesting.sol` and `OraclizeAPI.sol` from coveralls

