### PR TITLE
Improve variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,66 @@ Now run the tests:
 ## License
 
 MIT
+
+## Glossary
+
+### `Oracle`
+```
+Actions:
+
+   reward                    Reward rewardee for calling update on oracle
+   setAssetPrice             Called by Chainlink or Oraclize to update the asset price (Bitcoin)
+   setPaymentTokenPrice      Called by Chainlink to update the payment token price (LINK)
+
+
+Getters:
+
+   peek                      Return asset price without validating
+   read                      Return asset price with validation
+
+
+Vars:
+
+   assetPrice                Price of asset (Bitcoin)
+   assetPriceUpdated         Ture if setAssetPrice is called by Oraclize or Chainlink
+   asyncRequests             List of requests for updating the oracle
+   disbursement              Equal to payment amount if oracle requirements are satisfied after calling update on the oracle (price changed by at least 1%)
+   expiry                    Expiration time when oracle is considered no longer active or reliable (12 hours) 
+   payment                   Amount paid by the user to update the oracle
+   paymentTokenPrice         The price of the payment token (For Chainlink oracles: LINK)
+   paymentTokenPriceUpdated  True if setPaymentTokenPrice is called by Chainlink
+   rewardAmount              Amount rewardee receives if there are sufficient tokens after calling update on the oracle and receiving a response from Chainlink or Oraclize
+   rewardee                  Address of user that calls update with the intention of receiving a reward
+   timeout                   Delay until oracle `update` can be called again
+   token                     Token rewardee requests to receive when calling update on the oracle
+
+```
+
+
+### `Medianizer`
+```
+Actions:
+
+   compute                   Compute median of oracles
+   fund                      Send funds to oracles to be used for reward
+   poke                      Recompute the median of the oracles
+   setMaxReward              Called by deployer to setMaxReward for Chainlink Oracles (since there is no way to determine cost of call)
+   setOracles                Called by deployer once to set oracle addresses
+
+
+Getters:
+
+   peek                      Return asset price without validating
+   read                      Return asset price with validation
+
+
+Vars:
+
+   assetPrice                Price of asset (Bitcoin_)
+   deployer                  Oracle and Medianizer deployer
+   hasPrice                  True if asset price valid
+   minOraclesRequired        Minimum number of updated oracles required to get valid price
+   on                        Oracles set after deployment
+   oracles                   List of oracles
+   
+```

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -11,7 +11,7 @@ contract Medianizer is DSMath {
     bool on;
     address deployer;
 
-    Oracle[] public values;
+    Oracle[] public oracles;
 
     constructor() {
     	deployer = msg.sender;
@@ -20,32 +20,32 @@ contract Medianizer is DSMath {
     function setOracles(address[10] addrs) {
     	require(!on);
         require(msg.sender == deployer);
-        values.push(Oracle(addrs[0]));
-        values.push(Oracle(addrs[1]));
-        values.push(Oracle(addrs[2]));
-        values.push(Oracle(addrs[3]));
-        values.push(Oracle(addrs[4]));
-        values.push(Oracle(addrs[5]));
-        values.push(Oracle(addrs[6]));
-        values.push(Oracle(addrs[7]));
-        values.push(Oracle(addrs[8]));
-        values.push(Oracle(addrs[9]));
+        oracles.push(Oracle(addrs[0]));
+        oracles.push(Oracle(addrs[1]));
+        oracles.push(Oracle(addrs[2]));
+        oracles.push(Oracle(addrs[3]));
+        oracles.push(Oracle(addrs[4]));
+        oracles.push(Oracle(addrs[5]));
+        oracles.push(Oracle(addrs[6]));
+        oracles.push(Oracle(addrs[7]));
+        oracles.push(Oracle(addrs[8]));
+        oracles.push(Oracle(addrs[9]));
     	on = true;
     }
 
     function setMaxReward(uint256 maxReward_) {
     	require(on);
     	require(msg.sender == deployer);
-        values[0].setMaxReward(maxReward_);
-        values[1].setMaxReward(maxReward_);
-        values[2].setMaxReward(maxReward_);
-        values[3].setMaxReward(maxReward_);
-        values[4].setMaxReward(maxReward_);
-        values[5].setMaxReward(maxReward_);
-        values[6].setMaxReward(maxReward_);
-        values[7].setMaxReward(maxReward_);
-        values[8].setMaxReward(maxReward_);
-        values[9].setMaxReward(maxReward_);
+        oracles[0].setMaxReward(maxReward_);
+        oracles[1].setMaxReward(maxReward_);
+        oracles[2].setMaxReward(maxReward_);
+        oracles[3].setMaxReward(maxReward_);
+        oracles[4].setMaxReward(maxReward_);
+        oracles[5].setMaxReward(maxReward_);
+        oracles[6].setMaxReward(maxReward_);
+        oracles[7].setMaxReward(maxReward_);
+        oracles[8].setMaxReward(maxReward_);
+        oracles[9].setMaxReward(maxReward_);
     }
 
     function peek() public view returns (bytes32, bool) {
@@ -59,8 +59,8 @@ contract Medianizer is DSMath {
     }
 
     function push (uint256 amt, ERC20 tok) {
-      for (uint256 i = 0; i < values.length; i++) {
-        require(tok.transferFrom(msg.sender, address(values[i]), uint(div(uint128(amt), uint128(values.length)))));
+      for (uint256 i = 0; i < oracles.length; i++) {
+        require(tok.transferFrom(msg.sender, address(oracles[i]), uint(div(uint128(amt), uint128(oracles.length)))));
       }
     }
 
@@ -73,11 +73,11 @@ contract Medianizer is DSMath {
     }
 
     function compute() public returns (bytes32, bool) {
-        bytes32[] memory wuts = new bytes32[](values.length);
+        bytes32[] memory wuts = new bytes32[](oracles.length);
         uint256 ctr = 0;
-        for (uint256 i = 0; i < values.length; i++) {
-            if (address(values[i]) != 0) {
-                var (wut, wuz) = values[i].peek();
+        for (uint256 i = 0; i < oracles.length; i++) {
+            if (address(oracles[i]) != 0) {
+                var (wut, wuz) = oracles[i].peek();
                 if (wuz) {
                     if (ctr == 0 || wut >= wuts[ctr - 1]) {
                         wuts[ctr] = wut;

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -5,8 +5,8 @@ import "./DSMath.sol";
 pragma solidity ^0.4.26;
 
 contract Medianizer is DSMath {
-    bool    has;
-    bytes32 val;
+    bool    hasPrice;
+    bytes32 assetPrice;
     uint256 public min = 5;
     bool on;
     address deployer;
@@ -49,13 +49,13 @@ contract Medianizer is DSMath {
     }
 
     function peek() public view returns (bytes32, bool) {
-        return (val,has);
+        return (assetPrice,hasPrice);
     }
 
     function read() public returns (bytes32) {
-        var (wut, has) = peek();
-        assert(has);
-        return wut;
+        var (assetPrice, hasPrice) = peek();
+        assert(hasPrice);
+        return assetPrice;
     }
 
     function fund (uint256 amount, ERC20 token) {
@@ -69,7 +69,7 @@ contract Medianizer is DSMath {
     }
 
     function poke(bytes32) {
-        (val, has) = compute();
+        (assetPrice, hasPrice) = compute();
     }
 
     function compute() public returns (bytes32, bool) {
@@ -96,7 +96,7 @@ contract Medianizer is DSMath {
             }
         }
 
-        if (ctr < min) return (val, false);
+        if (ctr < min) return (assetPrice, false);
 
         bytes32 value;
         if (ctr % 2 == 0) {

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -58,9 +58,9 @@ contract Medianizer is DSMath {
         return wut;
     }
 
-    function push (uint256 amt, ERC20 tok) {
+    function fund (uint256 amount, ERC20 token) {
       for (uint256 i = 0; i < oracles.length; i++) {
-        require(tok.transferFrom(msg.sender, address(oracles[i]), uint(div(uint128(amt), uint128(oracles.length)))));
+        require(token.transferFrom(msg.sender, address(oracles[i]), uint(div(uint128(amount), uint128(oracles.length)))));
       }
     }
 

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -17,7 +17,7 @@ contract Medianizer is DSMath {
     	own = msg.sender;
     }
 
-    function set(address[10] addrs) {
+    function setOracles(address[10] addrs) {
     	require(!on);
         require(msg.sender == own);
         values.push(Oracle(addrs[0]));

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -33,19 +33,19 @@ contract Medianizer is DSMath {
     	on = true;
     }
 
-    function setMax(uint256 maxr_) {
+    function setMaxReward(uint256 maxReward_) {
     	require(on);
     	require(msg.sender == own);
-        values[0].setMax(maxr_);
-        values[1].setMax(maxr_);
-        values[2].setMax(maxr_);
-        values[3].setMax(maxr_);
-        values[4].setMax(maxr_);
-        values[5].setMax(maxr_);
-        values[6].setMax(maxr_);
-        values[7].setMax(maxr_);
-        values[8].setMax(maxr_);
-        values[9].setMax(maxr_);
+        values[0].setMaxReward(maxReward_);
+        values[1].setMaxReward(maxReward_);
+        values[2].setMaxReward(maxReward_);
+        values[3].setMaxReward(maxReward_);
+        values[4].setMaxReward(maxReward_);
+        values[5].setMaxReward(maxReward_);
+        values[6].setMaxReward(maxReward_);
+        values[7].setMaxReward(maxReward_);
+        values[8].setMaxReward(maxReward_);
+        values[9].setMaxReward(maxReward_);
     }
 
     function peek() public view returns (bytes32, bool) {

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -9,17 +9,17 @@ contract Medianizer is DSMath {
     bytes32 val;
     uint256 public min = 5;
     bool on;
-    address own;
+    address deployer;
 
     Oracle[] public values;
 
     constructor() {
-    	own = msg.sender;
+    	deployer = msg.sender;
     }
 
     function setOracles(address[10] addrs) {
     	require(!on);
-        require(msg.sender == own);
+        require(msg.sender == deployer);
         values.push(Oracle(addrs[0]));
         values.push(Oracle(addrs[1]));
         values.push(Oracle(addrs[2]));
@@ -35,7 +35,7 @@ contract Medianizer is DSMath {
 
     function setMaxReward(uint256 maxReward_) {
     	require(on);
-    	require(msg.sender == own);
+    	require(msg.sender == deployer);
         values[0].setMaxReward(maxReward_);
         values[1].setMaxReward(maxReward_);
         values[2].setMaxReward(maxReward_);

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.4.26;
 contract Medianizer is DSMath {
     bool    hasPrice;
     bytes32 assetPrice;
-    uint256 public min = 5;
+    uint256 public minOraclesRequired = 5;
     bool on;
     address deployer;
 
@@ -96,7 +96,7 @@ contract Medianizer is DSMath {
             }
         }
 
-        if (ctr < min) return (assetPrice, false);
+        if (ctr < minOraclesRequired) return (assetPrice, false);
 
         bytes32 value;
         if (ctr % 2 == 0) {

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -11,8 +11,8 @@ contract Oracle is DSMath {
 
     Medianizer med;
 
-    uint32 public zzz;
-    uint32 public lag;
+    uint32 public expiry;
+    uint32 public timeout;
     uint128 assetPrice;                     
     uint128 public paymentTokenPrice;
     uint256 gain;
@@ -31,22 +31,22 @@ contract Oracle is DSMath {
     function peek() public view
         returns (bytes32,bool)
     {
-        return (bytes32(uint(assetPrice)), now < zzz);
+        return (bytes32(uint(assetPrice)), now < expiry);
     }
 
     function read() public view
         returns (bytes32)
     {
-        assert(now < zzz);
+        assert(now < expiry);
         return bytes32(uint(assetPrice));
     }
     
-    function post(bytes32 queryId, uint128 assetPrice_, uint32 zzz_) internal
+    function post(bytes32 queryId, uint128 assetPrice_, uint32 expiry_) internal
     {
         areqs[queryId].dis = 0;
         if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { areqs[queryId].dis = areqs[queryId].pmt; }
         assetPrice = assetPrice_;
-        zzz = zzz_;
+        expiry = expiry_;
         med.poke();
         areqs[queryId].posted = true;
         if (areqs[queryId].told) { ward(queryId); }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -20,7 +20,7 @@ contract Oracle is DSMath {
     mapping(bytes32 => AsyncRequest) asyncRequests;
 
     struct AsyncRequest {
-        address owed;
+        address rewardee;
         uint128 pmt;
         uint128 dis;
         ERC20 tok;
@@ -61,7 +61,7 @@ contract Oracle is DSMath {
     function ward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
         if (asyncRequests[queryId].tok.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].dis > 0) {
-            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].owed, rewardAmount));
+            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, rewardAmount));
         }
         delete(asyncRequests[queryId]);
     }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -21,8 +21,8 @@ contract Oracle is DSMath {
 
     struct AsyncRequest {
         address rewardee;
-        uint128 pmt;
-        uint128 dis;
+        uint128 payment;
+        uint128 disbursement;
         ERC20 tok;
         bool posted;
         bool told;
@@ -43,8 +43,8 @@ contract Oracle is DSMath {
     
     function post(bytes32 queryId, uint128 assetPrice_, uint32 expiry_) internal
     {
-        asyncRequests[queryId].dis = 0;
-        if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { asyncRequests[queryId].dis = asyncRequests[queryId].pmt; }
+        asyncRequests[queryId].disbursement = 0;
+        if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { asyncRequests[queryId].disbursement = asyncRequests[queryId].payment; }
         assetPrice = assetPrice_;
         expiry = expiry_;
         med.poke();
@@ -59,8 +59,8 @@ contract Oracle is DSMath {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
-        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].dis > 0) {
+        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
+        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].disbursement > 0) {
             require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, rewardAmount));
         }
         delete(asyncRequests[queryId]);

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -49,16 +49,16 @@ contract Oracle is DSMath {
         expiry = expiry_;
         med.poke();
         asyncRequests[queryId].assetPriceSet = true;
-        if (asyncRequests[queryId].paymentTokenPriceSet) { ward(queryId); }
+        if (asyncRequests[queryId].paymentTokenPriceSet) { reward(queryId); }
     }
 
     function setPaymentTokenPrice(bytes32 queryId, uint128 paymentTokenPrice_) internal {
         paymentTokenPrice = paymentTokenPrice_;
         asyncRequests[queryId].paymentTokenPriceSet = true;
-        if (asyncRequests[queryId].assetPriceSet) { ward(queryId); }
+        if (asyncRequests[queryId].assetPriceSet) { reward(queryId); }
     }
 
-    function ward(bytes32 queryId) internal { // Reward
+    function reward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
         if (asyncRequests[queryId].token.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].disbursement > 0) {
             require(asyncRequests[queryId].token.transfer(asyncRequests[queryId].rewardee, rewardAmount));

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -24,8 +24,8 @@ contract Oracle is DSMath {
         uint128 payment;
         uint128 disbursement;
         ERC20 token;
-        bool posted;
-        bool told;
+        bool assetPriceSet;
+        bool paymentTokenPriceSet;
     }
 
     function peek() public view
@@ -41,21 +41,21 @@ contract Oracle is DSMath {
         return bytes32(uint(assetPrice));
     }
     
-    function post(bytes32 queryId, uint128 assetPrice_, uint32 expiry_) internal
+    function setAssetPrice(bytes32 queryId, uint128 assetPrice_, uint32 expiry_) internal
     {
         asyncRequests[queryId].disbursement = 0;
         if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { asyncRequests[queryId].disbursement = asyncRequests[queryId].payment; }
         assetPrice = assetPrice_;
         expiry = expiry_;
         med.poke();
-        asyncRequests[queryId].posted = true;
-        if (asyncRequests[queryId].told) { ward(queryId); }
+        asyncRequests[queryId].assetPriceSet = true;
+        if (asyncRequests[queryId].paymentTokenPriceSet) { ward(queryId); }
     }
 
-    function tell(bytes32 queryId, uint128 paymentTokenPrice_) internal {
+    function setPaymentTokenPrice(bytes32 queryId, uint128 paymentTokenPrice_) internal {
         paymentTokenPrice = paymentTokenPrice_;
-        asyncRequests[queryId].told = true;
-        if (asyncRequests[queryId].posted) { ward(queryId); }
+        asyncRequests[queryId].paymentTokenPriceSet = true;
+        if (asyncRequests[queryId].assetPriceSet) { ward(queryId); }
     }
 
     function ward(bytes32 queryId) internal { // Reward

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -17,9 +17,9 @@ contract Oracle is DSMath {
     uint128 public paymentTokenPrice;
     uint256 rewardAmount;
 
-    mapping(bytes32 => Areq) areqs;
+    mapping(bytes32 => AsyncRequest) asyncRequests;
 
-    struct Areq {
+    struct AsyncRequest {
         address owed;
         uint128 pmt;
         uint128 dis;
@@ -43,27 +43,27 @@ contract Oracle is DSMath {
     
     function post(bytes32 queryId, uint128 assetPrice_, uint32 expiry_) internal
     {
-        areqs[queryId].dis = 0;
-        if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { areqs[queryId].dis = areqs[queryId].pmt; }
+        asyncRequests[queryId].dis = 0;
+        if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { asyncRequests[queryId].dis = asyncRequests[queryId].pmt; }
         assetPrice = assetPrice_;
         expiry = expiry_;
         med.poke();
-        areqs[queryId].posted = true;
-        if (areqs[queryId].told) { ward(queryId); }
+        asyncRequests[queryId].posted = true;
+        if (asyncRequests[queryId].told) { ward(queryId); }
     }
 
     function tell(bytes32 queryId, uint128 paymentTokenPrice_) internal {
         paymentTokenPrice = paymentTokenPrice_;
-        areqs[queryId].told = true;
-        if (areqs[queryId].posted) { ward(queryId); }
+        asyncRequests[queryId].told = true;
+        if (asyncRequests[queryId].posted) { ward(queryId); }
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        rewardAmount = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
-        if (areqs[queryId].tok.balanceOf(address(this)) >= rewardAmount && areqs[queryId].dis > 0) {
-            require(areqs[queryId].tok.transfer(areqs[queryId].owed, rewardAmount));
+        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
+        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].dis > 0) {
+            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].owed, rewardAmount));
         }
-        delete(areqs[queryId]);
+        delete(asyncRequests[queryId]);
     }
 
     function setMaxReward(uint256 maxReward_) public;

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -13,8 +13,8 @@ contract Oracle is DSMath {
 
     uint32 public zzz;
     uint32 public lag;
-    uint128 val;                     
-    uint128 public lval;             // Link value
+    uint128 assetPrice;                     
+    uint128 public paymentTokenPrice;
     uint256 gain;
 
     mapping(bytes32 => Areq) areqs;
@@ -31,35 +31,35 @@ contract Oracle is DSMath {
     function peek() public view
         returns (bytes32,bool)
     {
-        return (bytes32(uint(val)), now < zzz);
+        return (bytes32(uint(assetPrice)), now < zzz);
     }
 
     function read() public view
         returns (bytes32)
     {
         assert(now < zzz);
-        return bytes32(uint(val));
+        return bytes32(uint(assetPrice));
     }
     
-    function post(bytes32 queryId, uint128 val_, uint32 zzz_) internal
+    function post(bytes32 queryId, uint128 assetPrice_, uint32 zzz_) internal
     {
         areqs[queryId].dis = 0;
-        if (val_ >= wmul(val, turn) || val_ <= wdiv(val, turn)) { areqs[queryId].dis = areqs[queryId].pmt; }
-        val = val_;
+        if (assetPrice_ >= wmul(assetPrice, turn) || assetPrice_ <= wdiv(assetPrice, turn)) { areqs[queryId].dis = areqs[queryId].pmt; }
+        assetPrice = assetPrice_;
         zzz = zzz_;
         med.poke();
         areqs[queryId].posted = true;
         if (areqs[queryId].told) { ward(queryId); }
     }
 
-    function tell(bytes32 queryId, uint128 lval_) internal {
-        lval = lval_;
+    function tell(bytes32 queryId, uint128 paymentTokenPrice_) internal {
+        paymentTokenPrice = paymentTokenPrice_;
         areqs[queryId].told = true;
         if (areqs[queryId].posted) { ward(queryId); }
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        gain = wmul(wmul(lval, areqs[queryId].dis), prem);
+        gain = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
         if (areqs[queryId].tok.balanceOf(address(this)) >= gain && areqs[queryId].dis > 0) {
             require(areqs[queryId].tok.transfer(areqs[queryId].owed, gain));
         }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -23,7 +23,7 @@ contract Oracle is DSMath {
         address rewardee;
         uint128 payment;
         uint128 disbursement;
-        ERC20 tok;
+        ERC20 token;
         bool posted;
         bool told;
     }
@@ -60,8 +60,8 @@ contract Oracle is DSMath {
 
     function ward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
-        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].disbursement > 0) {
-            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, rewardAmount));
+        if (asyncRequests[queryId].token.balanceOf(address(this)) >= rewardAmount && asyncRequests[queryId].disbursement > 0) {
+            require(asyncRequests[queryId].token.transfer(asyncRequests[queryId].rewardee, rewardAmount));
         }
         delete(asyncRequests[queryId]);
     }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -15,7 +15,7 @@ contract Oracle is DSMath {
     uint32 public timeout;
     uint128 assetPrice;                     
     uint128 public paymentTokenPrice;
-    uint256 gain;
+    uint256 rewardAmount;
 
     mapping(bytes32 => Areq) areqs;
 
@@ -59,9 +59,9 @@ contract Oracle is DSMath {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        gain = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
-        if (areqs[queryId].tok.balanceOf(address(this)) >= gain && areqs[queryId].dis > 0) {
-            require(areqs[queryId].tok.transfer(areqs[queryId].owed, gain));
+        rewardAmount = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
+        if (areqs[queryId].tok.balanceOf(address(this)) >= rewardAmount && areqs[queryId].dis > 0) {
+            require(areqs[queryId].tok.transfer(areqs[queryId].owed, rewardAmount));
         }
         delete(areqs[queryId]);
     }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -66,5 +66,5 @@ contract Oracle is DSMath {
         delete(areqs[queryId]);
     }
 
-    function setMax(uint256 maxr_) public;
+    function setMaxReward(uint256 maxReward_) public;
 }

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -13,7 +13,7 @@ contract BlockchainInfo is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 payment) internal returns (bytes32 queryId) {
+    function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://blockchain.info/ticker?currency=USD");
         req.add("path", "USD.last");

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -13,22 +13,22 @@ contract BlockchainInfo is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 pmt) internal returns (bytes32 queryId) {
+    function call(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://blockchain.info/ticker?currency=USD");
         req.add("path", "USD.last");
         req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(payment, 2));
         linkrs[linkrId] = queryId;
         return linkrId;
     }

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -14,7 +14,7 @@ contract BlockchainInfo is ChainLink {
     {}
 
     function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://blockchain.info/ticker?currency=USD");
         req.add("path", "USD.last");
         req.addInt("times", 1000000000000000000);
@@ -22,7 +22,7 @@ contract BlockchainInfo is ChainLink {
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.returnPaymentTokenPrice.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");

--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -21,7 +21,7 @@ contract BlockchainInfo is ChainLink {
         queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -28,7 +28,7 @@ contract ChainLink is ChainlinkClient, Oracle {
     }
 
     function pack(uint128 pmt_, ERC20 tok_) { // payment
-        require(uint32(now) > lag);
+        require(uint32(now) > timeout);
         require(link.transferFrom(msg.sender, address(this), uint(pmt_)));
         bytes32 queryId = call(pmt_);
         lastQueryId = queryId;
@@ -37,7 +37,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         areqs[queryId].owed = msg.sender;
         areqs[queryId].pmt  = pmt_;
         areqs[queryId].tok  = tok_;
-        lag = uint32(now) + DELAY;
+        timeout = uint32(now) + DELAY;
     }
 
     function call(uint128 pmt) internal returns (bytes32);

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -27,7 +27,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         return asyncRequests[lastQueryId].payment;
     }
 
-    function pack(uint128 payment_, ERC20 tok_) { // payment
+    function pack(uint128 payment_, ERC20 token_) { // payment
         require(uint32(now) > timeout);
         require(link.transferFrom(msg.sender, address(this), uint(payment_)));
         bytes32 queryId = call(payment_);
@@ -36,7 +36,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         linkrs[linkrId] = queryId;
         asyncRequests[queryId].rewardee = msg.sender;
         asyncRequests[queryId].payment  = payment_;
-        asyncRequests[queryId].tok      = tok_;
+        asyncRequests[queryId].token    = token_;
         timeout = uint32(now) + DELAY;
     }
 
@@ -60,8 +60,8 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     function ward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
-        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].disbursement > 0) {
-            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, min(maxReward, rewardAmount)));
+        if (asyncRequests[queryId].token.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].disbursement > 0) {
+            require(asyncRequests[queryId].token.transfer(asyncRequests[queryId].rewardee, min(maxReward, rewardAmount)));
         }
     }
 

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -59,7 +59,7 @@ contract ChainLink is ChainlinkClient, Oracle {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        gain = wmul(wmul(lval, areqs[queryId].dis), prem);
+        gain = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
         if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxReward, gain) && areqs[queryId].dis > 0) {
             require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxReward, gain)));
         }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -48,14 +48,14 @@ contract ChainLink is ChainlinkClient, Oracle {
         public
         recordChainlinkFulfillment(_requestId)
     {
-        post(_requestId, uint128(_price), uint32(now + 43200));
+        setAssetPrice(_requestId, uint128(_price), uint32(now + 43200));
     }
     
     function sup(bytes32 _requestId, uint256 _price) // Supply Currency
         public
         recordChainlinkFulfillment(_requestId)
     {
-        tell(linkrs[_requestId], uint128(_price));
+        setPaymentTokenPrice(linkrs[_requestId], uint128(_price));
     }
 
     function ward(bytes32 queryId) internal { // Reward

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -27,7 +27,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         return asyncRequests[lastQueryId].payment;
     }
 
-    function pack(uint128 payment_, ERC20 token_) { // payment
+    function update(uint128 payment_, ERC20 token_) { // payment
         require(uint32(now) > timeout);
         require(link.transferFrom(msg.sender, address(this), uint(payment_)));
         bytes32 queryId = getAssetPrice(payment_);

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -34,9 +34,9 @@ contract ChainLink is ChainlinkClient, Oracle {
         lastQueryId = queryId;
         bytes32 linkrId = chec(pmt_, queryId);
         linkrs[linkrId] = queryId;
-        asyncRequests[queryId].owed = msg.sender;
-        asyncRequests[queryId].pmt  = pmt_;
-        asyncRequests[queryId].tok  = tok_;
+        asyncRequests[queryId].rewardee = msg.sender;
+        asyncRequests[queryId].pmt      = pmt_;
+        asyncRequests[queryId].tok      = tok_;
         timeout = uint32(now) + DELAY;
     }
 
@@ -61,7 +61,7 @@ contract ChainLink is ChainlinkClient, Oracle {
     function ward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
         if (asyncRequests[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].dis > 0) {
-            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].owed, min(maxReward, rewardAmount)));
+            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, min(maxReward, rewardAmount)));
         }
     }
 

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -58,7 +58,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         setPaymentTokenPrice(linkrs[_requestId], uint128(_price));
     }
 
-    function ward(bytes32 queryId) internal { // Reward
+    function reward(bytes32 queryId) internal { // Reward
         rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
         if (asyncRequests[queryId].token.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].disbursement > 0) {
             require(asyncRequests[queryId].token.transfer(asyncRequests[queryId].rewardee, min(maxReward, rewardAmount)));

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -30,7 +30,7 @@ contract ChainLink is ChainlinkClient, Oracle {
     function pack(uint128 payment_, ERC20 token_) { // payment
         require(uint32(now) > timeout);
         require(link.transferFrom(msg.sender, address(this), uint(payment_)));
-        bytes32 queryId = call(payment_);
+        bytes32 queryId = getAssetPrice(payment_);
         lastQueryId = queryId;
         bytes32 linkrId = chec(payment_, queryId);
         linkrs[linkrId] = queryId;
@@ -40,7 +40,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         timeout = uint32(now) + DELAY;
     }
 
-    function call(uint128 payment) internal returns (bytes32);
+    function getAssetPrice(uint128 payment) internal returns (bytes32);
 
     function chec(uint128 payment, bytes32 queryId) internal returns (bytes32);
 

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -7,7 +7,7 @@ import "../ERC20.sol";
 
 contract ChainLink is ChainlinkClient, Oracle {
     ERC20 link;
-    uint256 maxr; // Max reward
+    uint256 maxReward; // Max reward
 
     bytes32 public lastQueryId;
 
@@ -60,13 +60,13 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     function ward(bytes32 queryId) internal { // Reward
         gain = wmul(wmul(lval, areqs[queryId].dis), prem);
-        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxr, gain) && areqs[queryId].dis > 0) {
-            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxr, gain)));
+        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxReward, gain) && areqs[queryId].dis > 0) {
+            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxReward, gain)));
         }
     }
 
-    function setMax(uint256 maxr_) public {
+    function setMaxReward(uint256 maxReward_) public {
         require(msg.sender == address(med));
-        maxr = maxr_;
+        maxReward = maxReward_;
     }
 }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -32,7 +32,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         require(link.transferFrom(msg.sender, address(this), uint(payment_)));
         bytes32 queryId = getAssetPrice(payment_);
         lastQueryId = queryId;
-        bytes32 linkrId = chec(payment_, queryId);
+        bytes32 linkrId = getPaymentTokenPrice(payment_, queryId);
         linkrs[linkrId] = queryId;
         asyncRequests[queryId].rewardee = msg.sender;
         asyncRequests[queryId].payment  = payment_;
@@ -42,7 +42,7 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     function getAssetPrice(uint128 payment) internal returns (bytes32);
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32);
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32);
 
     function cur(bytes32 _requestId, uint256 _price) // Currency
         public

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -20,29 +20,29 @@ contract ChainLink is ChainlinkClient, Oracle {
         link = link_;
         setChainlinkToken(address(link_));
         setChainlinkOracle(oracle_);
-        asyncRequests[lastQueryId].pmt = uint128(2 * LINK);
+        asyncRequests[lastQueryId].payment = uint128(2 * LINK);
     }
 
     function bill() public view returns (uint256) {
-        return asyncRequests[lastQueryId].pmt;
+        return asyncRequests[lastQueryId].payment;
     }
 
-    function pack(uint128 pmt_, ERC20 tok_) { // payment
+    function pack(uint128 payment_, ERC20 tok_) { // payment
         require(uint32(now) > timeout);
-        require(link.transferFrom(msg.sender, address(this), uint(pmt_)));
-        bytes32 queryId = call(pmt_);
+        require(link.transferFrom(msg.sender, address(this), uint(payment_)));
+        bytes32 queryId = call(payment_);
         lastQueryId = queryId;
-        bytes32 linkrId = chec(pmt_, queryId);
+        bytes32 linkrId = chec(payment_, queryId);
         linkrs[linkrId] = queryId;
         asyncRequests[queryId].rewardee = msg.sender;
-        asyncRequests[queryId].pmt      = pmt_;
+        asyncRequests[queryId].payment  = payment_;
         asyncRequests[queryId].tok      = tok_;
         timeout = uint32(now) + DELAY;
     }
 
-    function call(uint128 pmt) internal returns (bytes32);
+    function call(uint128 payment) internal returns (bytes32);
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32);
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32);
 
     function cur(bytes32 _requestId, uint256 _price) // Currency
         public
@@ -59,8 +59,8 @@ contract ChainLink is ChainlinkClient, Oracle {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
-        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].dis > 0) {
+        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].disbursement), prem);
+        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].disbursement > 0) {
             require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].rewardee, min(maxReward, rewardAmount)));
         }
     }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -44,14 +44,14 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32);
 
-    function cur(bytes32 _requestId, uint256 _price) // Currency
+    function returnAssetPrice(bytes32 _requestId, uint256 _price) // Currency
         public
         recordChainlinkFulfillment(_requestId)
     {
         setAssetPrice(_requestId, uint128(_price), uint32(now + 43200));
     }
     
-    function sup(bytes32 _requestId, uint256 _price) // Supply Currency
+    function returnPaymentTokenPrice(bytes32 _requestId, uint256 _price) // Supply Currency
         public
         recordChainlinkFulfillment(_requestId)
     {

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -20,11 +20,11 @@ contract ChainLink is ChainlinkClient, Oracle {
         link = link_;
         setChainlinkToken(address(link_));
         setChainlinkOracle(oracle_);
-        areqs[lastQueryId].pmt = uint128(2 * LINK);
+        asyncRequests[lastQueryId].pmt = uint128(2 * LINK);
     }
 
     function bill() public view returns (uint256) {
-        return areqs[lastQueryId].pmt;
+        return asyncRequests[lastQueryId].pmt;
     }
 
     function pack(uint128 pmt_, ERC20 tok_) { // payment
@@ -34,9 +34,9 @@ contract ChainLink is ChainlinkClient, Oracle {
         lastQueryId = queryId;
         bytes32 linkrId = chec(pmt_, queryId);
         linkrs[linkrId] = queryId;
-        areqs[queryId].owed = msg.sender;
-        areqs[queryId].pmt  = pmt_;
-        areqs[queryId].tok  = tok_;
+        asyncRequests[queryId].owed = msg.sender;
+        asyncRequests[queryId].pmt  = pmt_;
+        asyncRequests[queryId].tok  = tok_;
         timeout = uint32(now) + DELAY;
     }
 
@@ -59,9 +59,9 @@ contract ChainLink is ChainlinkClient, Oracle {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        rewardAmount = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
-        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && areqs[queryId].dis > 0) {
-            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxReward, rewardAmount)));
+        rewardAmount = wmul(wmul(paymentTokenPrice, asyncRequests[queryId].dis), prem);
+        if (asyncRequests[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && asyncRequests[queryId].dis > 0) {
+            require(asyncRequests[queryId].tok.transfer(asyncRequests[queryId].owed, min(maxReward, rewardAmount)));
         }
     }
 

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -59,9 +59,9 @@ contract ChainLink is ChainlinkClient, Oracle {
     }
 
     function ward(bytes32 queryId) internal { // Reward
-        gain = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
-        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxReward, gain) && areqs[queryId].dis > 0) {
-            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxReward, gain)));
+        rewardAmount = wmul(wmul(paymentTokenPrice, areqs[queryId].dis), prem);
+        if (areqs[queryId].tok.balanceOf(address(this)) >= min(maxReward, rewardAmount) && areqs[queryId].dis > 0) {
+            require(areqs[queryId].tok.transfer(areqs[queryId].owed, min(maxReward, rewardAmount)));
         }
     }
 

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -26,7 +26,7 @@ contract CoinMarketCap is ChainLink {
         queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("sym", "LINK");
         req.add("convert", "USD");

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -11,7 +11,7 @@ contract CoinMarketCap is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 payment) internal returns (bytes32 queryId) {
+    function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("sym", "BTC");
         req.add("convert", "USD");

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -12,7 +12,7 @@ contract CoinMarketCap is ChainLink {
     {}
 
     function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("sym", "BTC");
         req.add("convert", "USD");
         string[] memory path = new string[](5);
@@ -27,7 +27,7 @@ contract CoinMarketCap is ChainLink {
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnPaymentTokenPrice.selector);
         req.add("sym", "LINK");
         req.add("convert", "USD");
         string[] memory path = new string[](5);

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -11,7 +11,7 @@ contract CoinMarketCap is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 pmt) internal returns (bytes32 queryId) {
+    function call(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("sym", "BTC");
         req.add("convert", "USD");
@@ -23,10 +23,10 @@ contract CoinMarketCap is ChainLink {
         path[4] = "price";
         req.addStringArray("copyPath", path);
         req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("sym", "LINK");
         req.add("convert", "USD");
@@ -38,7 +38,7 @@ contract CoinMarketCap is ChainLink {
         path[4] = "price";
         req.addStringArray("copyPath", path);
         req.addInt("times", 1000000000000000000);
-        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(payment, 2));
         linkrs[linkrId] = queryId;
         return linkrId;
     }

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -12,7 +12,7 @@ contract CryptoCompare is ChainLink {
     {}
 
     function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("endpoint", "price");
         req.add("fsym", "BTC");
         req.add("tsyms", "USD");
@@ -22,7 +22,7 @@ contract CryptoCompare is ChainLink {
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnPaymentTokenPrice.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -21,7 +21,7 @@ contract CryptoCompare is ChainLink {
         queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -11,24 +11,24 @@ contract CryptoCompare is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 pmt) internal returns (bytes32 queryId) {
+    function call(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("endpoint", "price");
         req.add("fsym", "BTC");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(payment, 2));
         linkrs[linkrId] = queryId;
         return linkrId;
     }

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -11,7 +11,7 @@ contract CryptoCompare is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 payment) internal returns (bytes32 queryId) {
+    function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("endpoint", "price");
         req.add("fsym", "BTC");

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -21,7 +21,7 @@ contract Gemini is ChainLink {
         queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -13,22 +13,22 @@ contract Gemini is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 pmt) internal returns (bytes32 queryId) {
+    function call(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://api.gemini.com/v1/pubticker/btcusd");
         req.add("path", "last");
         req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(payment, 2));
         linkrs[linkrId] = queryId;
         return linkrId;
     }

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -13,7 +13,7 @@ contract Gemini is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 payment) internal returns (bytes32 queryId) {
+    function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://api.gemini.com/v1/pubticker/btcusd");
         req.add("path", "last");

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -14,7 +14,7 @@ contract Gemini is ChainLink {
     {}
 
     function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://api.gemini.com/v1/pubticker/btcusd");
         req.add("path", "last");
         req.addInt("times", 1000000000000000000);
@@ -22,7 +22,7 @@ contract Gemini is ChainLink {
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.returnPaymentTokenPrice.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -14,7 +14,7 @@ contract SoChain is ChainLink {
     {}
 
     function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://chain.so/api/v2/get_info/BTC");
         req.add("path", "data.price");
         req.addInt("times", 1000000000000000000);
@@ -22,7 +22,7 @@ contract SoChain is ChainLink {
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
-        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.returnPaymentTokenPrice.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -13,22 +13,22 @@ contract SoChain is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 pmt) internal returns (bytes32 queryId) {
+    function call(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://chain.so/api/v2/get_info/BTC");
         req.add("path", "data.price");
         req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(pmt, 2));
+        queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 pmt, bytes32 queryId) internal returns (bytes32) {
+    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
         req.addInt("times", 1000000000000000000);
-        bytes32 linkrId = sendChainlinkRequest(req, div(pmt, 2));
+        bytes32 linkrId = sendChainlinkRequest(req, div(payment, 2));
         linkrs[linkrId] = queryId;
         return linkrId;
     }

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -13,7 +13,7 @@ contract SoChain is ChainLink {
         ChainLink(med_, link_, oracle_)
     {}
 
-    function call(uint128 payment) internal returns (bytes32 queryId) {
+    function getAssetPrice(uint128 payment) internal returns (bytes32 queryId) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.cur.selector);
         req.add("get", "https://chain.so/api/v2/get_info/BTC");
         req.add("path", "data.price");

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -21,7 +21,7 @@ contract SoChain is ChainLink {
         queryId = sendChainlinkRequest(req, div(payment, 2));
     }
 
-    function chec(uint128 payment, bytes32 queryId) internal returns (bytes32) {
+    function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB__LINK, this, this.sup.selector);
         req.add("endpoint", "price");
         req.add("fsym", "LINK");

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -8,10 +8,10 @@ contract Bitstamp is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 pmt)
+    function call(uint128 payment)
         internal returns (bytes32 queryId)
     {
-        weth.withdraw(pmt);
+        weth.withdraw(payment);
         require(oraclize_getPrice("URL") <= address(this).balance);
         queryId = oraclize_query("URL", "json(https://www.bitstamp.net/api/v2/ticker/btcusd).last");
     }

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -8,7 +8,7 @@ contract Bitstamp is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 payment)
+    function getAssetPrice(uint128 payment)
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment);

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -8,10 +8,10 @@ contract Coinbase is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 pmt)
+    function call(uint128 payment)
         internal returns (bytes32 queryId)
     {
-        weth.withdraw(pmt);
+        weth.withdraw(payment);
         require(oraclize_getPrice("URL") <= address(this).balance);
         queryId = oraclize_query("URL", "json(https://api.pro.coinbase.com/products/BTC-USD/ticker).price");
     }

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -8,7 +8,7 @@ contract Coinbase is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 payment)
+    function getAssetPrice(uint128 payment)
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment);

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -8,7 +8,7 @@ contract Coinpaprika is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 payment)
+    function getAssetPrice(uint128 payment)
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment);

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -8,10 +8,10 @@ contract Coinpaprika is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 pmt)
+    function call(uint128 payment)
         internal returns (bytes32 queryId)
     {
-        weth.withdraw(pmt);
+        weth.withdraw(payment);
         require(oraclize_getPrice("URL") <= address(this).balance);
         queryId = oraclize_query("URL", "json(https://api.coinpaprika.com/v1/tickers/btc-bitcoin).quotes.USD.price");
     }

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -8,7 +8,7 @@ contract CryptoWatch is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 payment)
+    function getAssetPrice(uint128 payment)
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment);

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -8,10 +8,10 @@ contract CryptoWatch is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 pmt)
+    function call(uint128 payment)
         internal returns (bytes32 queryId)
     {
-        weth.withdraw(pmt);
+        weth.withdraw(payment);
         require(oraclize_getPrice("URL") <= address(this).balance);
         queryId = oraclize_query("URL", "json(https://api.cryptowat.ch/markets/coinbase-pro/btcusd/price).result.price");
     }

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -8,10 +8,10 @@ contract Kraken is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 pmt)
+    function call(uint128 payment)
         internal returns (bytes32 queryId)
     {
-        weth.withdraw(pmt);
+        weth.withdraw(payment);
         require(oraclize_getPrice("URL") <= address(this).balance);
         queryId = oraclize_query("URL", "json(https://api.kraken.com/0/public/Ticker?pair=XBTUSD).result.XXBTZUSD.c.0");
     }

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -8,7 +8,7 @@ contract Kraken is Oraclize {
         Oraclize(med_, medm_, weth_)
     {}
 
-    function call(uint128 payment)
+    function getAssetPrice(uint128 payment)
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment);

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -32,7 +32,7 @@ contract Oraclize is usingOraclize, Oracle {
         require(uint32(now) > timeout);
         require(payment_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(payment_)));
-        bytes32 queryId = call(payment_);
+        bytes32 queryId = getAssetPrice(payment_);
         setPaymentTokenPrice(queryId, uint128(medm.read()));
         asyncRequests[queryId].rewardee = msg.sender;
         asyncRequests[queryId].payment  = payment_;
@@ -40,7 +40,7 @@ contract Oraclize is usingOraclize, Oracle {
         timeout = uint32(now) + DELAY;
     }
 
-    function call(uint128 payment) internal returns (bytes32);
+    function getAssetPrice(uint128 payment) internal returns (bytes32);
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -29,7 +29,7 @@ contract Oraclize is usingOraclize, Oracle {
     }
     
     function pack(uint128 pmt_, ERC20 tok_) { // payment
-        require(uint32(now) > lag);
+        require(uint32(now) > timeout);
         require(pmt_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
         bytes32 queryId = call(pmt_);
@@ -37,7 +37,7 @@ contract Oraclize is usingOraclize, Oracle {
         areqs[queryId].owed = msg.sender;
         areqs[queryId].pmt  = pmt_;
         areqs[queryId].tok  = tok_;
-        lag = uint32(now) + DELAY;
+        timeout = uint32(now) + DELAY;
     }
 
     function call(uint128 pmt) internal returns (bytes32);

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -49,7 +49,7 @@ contract Oraclize is usingOraclize, Oracle {
         post(myid, res, uint32(now + 43200));
     }
 
-    function setMax(uint256 maxr_) public {
+    function setMaxReward(uint256 maxReward_) public {
         require(msg.sender == address(med));
     }
 }

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -28,19 +28,19 @@ contract Oraclize is usingOraclize, Oracle {
         pack(uint128(bill()), tok_);   
     }
     
-    function pack(uint128 pmt_, ERC20 tok_) { // payment
+    function pack(uint128 payment_, ERC20 tok_) { // payment
         require(uint32(now) > timeout);
-        require(pmt_ == oraclize_getPrice("URL"));
-        require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
-        bytes32 queryId = call(pmt_);
+        require(payment_ == oraclize_getPrice("URL"));
+        require(weth.transferFrom(msg.sender, address(this), uint(payment_)));
+        bytes32 queryId = call(payment_);
         tell(queryId, uint128(medm.read()));
         asyncRequests[queryId].rewardee = msg.sender;
-        asyncRequests[queryId].pmt      = pmt_;
+        asyncRequests[queryId].payment  = payment_;
         asyncRequests[queryId].tok      = tok_;
         timeout = uint32(now) + DELAY;
     }
 
-    function call(uint128 pmt) internal returns (bytes32);
+    function call(uint128 payment) internal returns (bytes32);
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -34,9 +34,9 @@ contract Oraclize is usingOraclize, Oracle {
         require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
         bytes32 queryId = call(pmt_);
         tell(queryId, uint128(medm.read()));
-        asyncRequests[queryId].owed = msg.sender;
-        asyncRequests[queryId].pmt  = pmt_;
-        asyncRequests[queryId].tok  = tok_;
+        asyncRequests[queryId].rewardee = msg.sender;
+        asyncRequests[queryId].pmt      = pmt_;
+        asyncRequests[queryId].tok      = tok_;
         timeout = uint32(now) + DELAY;
     }
 
@@ -44,7 +44,7 @@ contract Oraclize is usingOraclize, Oracle {
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());
-        require(asyncRequests[myid].owed != address(0));
+        require(asyncRequests[myid].rewardee != address(0));
         uint128 res = uint128(parseInt(result, 18));
         post(myid, res, uint32(now + 43200));
     }

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -24,11 +24,7 @@ contract Oraclize is usingOraclize, Oracle {
         return oraclize_getPrice("URL");
     }
     
-    function pack(ERC20 token_) {
-        pack(uint128(bill()), token_);   
-    }
-    
-    function pack(uint128 payment_, ERC20 token_) { // payment
+    function update(uint128 payment_, ERC20 token_) { // payment
         require(uint32(now) > timeout);
         require(payment_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(payment_)));

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -24,11 +24,11 @@ contract Oraclize is usingOraclize, Oracle {
         return oraclize_getPrice("URL");
     }
     
-    function pack(ERC20 tok_) {
-        pack(uint128(bill()), tok_);   
+    function pack(ERC20 token_) {
+        pack(uint128(bill()), token_);   
     }
     
-    function pack(uint128 payment_, ERC20 tok_) { // payment
+    function pack(uint128 payment_, ERC20 token_) { // payment
         require(uint32(now) > timeout);
         require(payment_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(payment_)));
@@ -36,7 +36,7 @@ contract Oraclize is usingOraclize, Oracle {
         tell(queryId, uint128(medm.read()));
         asyncRequests[queryId].rewardee = msg.sender;
         asyncRequests[queryId].payment  = payment_;
-        asyncRequests[queryId].tok      = tok_;
+        asyncRequests[queryId].token    = token_;
         timeout = uint32(now) + DELAY;
     }
 

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -33,7 +33,7 @@ contract Oraclize is usingOraclize, Oracle {
         require(payment_ == oraclize_getPrice("URL"));
         require(weth.transferFrom(msg.sender, address(this), uint(payment_)));
         bytes32 queryId = call(payment_);
-        tell(queryId, uint128(medm.read()));
+        setPaymentTokenPrice(queryId, uint128(medm.read()));
         asyncRequests[queryId].rewardee = msg.sender;
         asyncRequests[queryId].payment  = payment_;
         asyncRequests[queryId].token    = token_;
@@ -46,7 +46,7 @@ contract Oraclize is usingOraclize, Oracle {
         require(msg.sender == oraclize_cbAddress());
         require(asyncRequests[myid].rewardee != address(0));
         uint128 res = uint128(parseInt(result, 18));
-        post(myid, res, uint32(now + 43200));
+        setAssetPrice(myid, res, uint32(now + 43200));
     }
 
     function setMaxReward(uint256 maxReward_) public {

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -34,9 +34,9 @@ contract Oraclize is usingOraclize, Oracle {
         require(weth.transferFrom(msg.sender, address(this), uint(pmt_)));
         bytes32 queryId = call(pmt_);
         tell(queryId, uint128(medm.read()));
-        areqs[queryId].owed = msg.sender;
-        areqs[queryId].pmt  = pmt_;
-        areqs[queryId].tok  = tok_;
+        asyncRequests[queryId].owed = msg.sender;
+        asyncRequests[queryId].pmt  = pmt_;
+        asyncRequests[queryId].tok  = tok_;
         timeout = uint32(now) + DELAY;
     }
 
@@ -44,7 +44,7 @@ contract Oraclize is usingOraclize, Oracle {
     
     function __callback(bytes32 myid, string result, bytes proof) {
         require(msg.sender == oraclize_cbAddress());
-        require(areqs[myid].owed != address(0));
+        require(asyncRequests[myid].owed != address(0));
         uint128 res = uint128(parseInt(result, 18));
         post(myid, res, uint32(now + 43200));
     }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -47,6 +47,6 @@ module.exports = function(deployer) {
     var coinpaprika = await Coinpaprika.deployed();
     await deployer.deploy(Kraken, medianizer.address, makerMedianizer.address, weth9.address);
     var kraken = await Kraken.deployed();
-    await medianizer.set([blockchainInfo.address, coinMarketCap.address, cryptoCompare.address, gemini.address, soChain.address, bitstamp.address, coinbase.address, cryptoWatch.address, coinpaprika.address, kraken.address]);
+    await medianizer.setOracles([blockchainInfo.address, coinMarketCap.address, cryptoCompare.address, gemini.address, soChain.address, bitstamp.address, coinbase.address, cryptoWatch.address, coinpaprika.address, kraken.address]);
   })
 };

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -64,9 +64,9 @@ contract("Chainlink", accounts => {
     it('should fail if trying to pack twice before 15 minutes is up', async function() {
       await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
 
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
 
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await expectRevert.unspecified(this.blockchainInfo.pack(this.bill, this.token.address), { from: updater })
     })
@@ -76,9 +76,9 @@ contract("Chainlink", accounts => {
 
       await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
 
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12656.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12656.71', 'ether'), { from: chainlink })
 
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       const read = await this.blockchainInfo.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))
@@ -100,9 +100,9 @@ contract("Chainlink", accounts => {
 
       const balBefore = await this.token.balanceOf.call(updater)
 
-      await this.blockchainInfo.cur(tx.logs[0].args.id, toWei('12783.31', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(tx.logs[0].args.id, toWei('12783.31', 'ether'), { from: chainlink })
 
-      await this.blockchainInfo.sup(tx.logs[1].args.id, toWei('5.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(tx.logs[1].args.id, toWei('5.19', 'ether'), { from: chainlink })
 
       const balAfter = await this.token.balanceOf.call(updater)
 

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -55,7 +55,7 @@ contract("Chainlink", accounts => {
 
     await this.token.approve(this.med.address, toWei('100', 'ether'))
 
-    await this.med.push(toWei('100', 'ether'), this.token.address)
+    await this.med.fund(toWei('100', 'ether'), this.token.address)
 
     await this.link.approve(this.blockchainInfo.address, toWei('100', 'ether'), { from: updater })
   })

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -94,7 +94,7 @@ contract("Chainlink", accounts => {
     it('should reward correct based on max', async function() {
       await time.increase(901)
 
-      await this.med.setMax(toWei('10', 'ether'), { from: own })
+      await this.med.setMaxReward(toWei('10', 'ether'), { from: own })
 
       const tx = await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
 

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -62,19 +62,19 @@ contract("Chainlink", accounts => {
 
   describe('pack', function() {
     it('should fail if trying to pack twice before 15 minutes is up', async function() {
-      await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.bill, this.token.address, { from: updater })
 
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
 
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await expectRevert.unspecified(this.blockchainInfo.pack(this.bill, this.token.address), { from: updater })
+      await expectRevert.unspecified(this.blockchainInfo.update(this.bill, this.token.address), { from: updater })
     })
 
     it('should succeed in updating price of called once', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.bill, this.token.address, { from: updater })
 
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12656.71', 'ether'), { from: chainlink })
 
@@ -96,7 +96,7 @@ contract("Chainlink", accounts => {
 
       await this.med.setMaxReward(toWei('10', 'ether'), { from: own })
 
-      const tx = await this.blockchainInfo.pack(this.bill, this.token.address, { from: updater })
+      const tx = await this.blockchainInfo.update(this.bill, this.token.address, { from: updater })
 
       const balBefore = await this.token.balanceOf.call(updater)
 

--- a/test/chainlink.js
+++ b/test/chainlink.js
@@ -83,8 +83,8 @@ contract("Chainlink", accounts => {
       const read = await this.blockchainInfo.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))
 
-      const lval = await this.blockchainInfo.lval.call()
-      assert.equal(toWei('3.19', 'ether'), lval)
+      const paymentTokenPrice = await this.blockchainInfo.paymentTokenPrice.call()
+      assert.equal(toWei('3.19', 'ether'), paymentTokenPrice)
 
       const peek = await this.blockchainInfo.peek.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(peek[0]))

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -99,12 +99,12 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(padRight('0x', 64), '12529.71')
@@ -117,16 +117,16 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
@@ -143,24 +143,24 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.gemini.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.gemini.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.soChain.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
@@ -186,24 +186,24 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12000', 'ether'), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12000', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('13000', 'ether'), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('13000', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('14000', 'ether'), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('14000', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.gemini.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('15000', 'ether'), { from: chainlink })
-      await this.gemini.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('15000', 'ether'), { from: chainlink })
+      await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.soChain.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('16000', 'ether'), { from: chainlink })
-      await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('16000', 'ether'), { from: chainlink })
+      await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '17000')
@@ -229,24 +229,24 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.gemini.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.gemini.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.soChain.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
-      await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
+      await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
@@ -277,24 +277,24 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.gemini.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
-      await this.gemini.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
+      await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.soChain.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
-      await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
+      await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       const read = await this.med.read.call()
 
@@ -305,24 +305,24 @@ contract("Medianizer", accounts => {
       await time.increase(901)
 
       await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.blockchainInfo.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
-      await this.blockchainInfo.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
+      await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.coinMarketCap.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
-      await this.coinMarketCap.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
+      await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.cryptoCompare.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
-      await this.cryptoCompare.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
+      await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.gemini.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
-      await this.gemini.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
+      await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
-      await this.soChain.cur(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
-      await this.soChain.sup(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
+      await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
+      await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
       const read = await this.med.read.call()
 

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -85,10 +85,10 @@ contract("Medianizer", accounts => {
     await this.weth.approve(this.coinpaprika.address,    toWei('1', 'ether'), { from: updater })
     await this.weth.approve(this.kraken.address,         toWei('1', 'ether'), { from: updater })
 
-    await this.med.push(toWei('100', 'ether'), this.token.address)
+    await this.med.fund(toWei('100', 'ether'), this.token.address)
   })
 
-  describe('push', function() {
+  describe('fund', function() {
     it('should send funds to all oracle contracts', async function() {
       const bal  = await this.token.balanceOf.call(this.blockchainInfo.address)
 

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -98,15 +98,15 @@ contract("Medianizer", accounts => {
     it('should not return median for oracles if less than 5 are set', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.kraken.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       const peek = await this.med.peek.call()
@@ -116,22 +116,22 @@ contract("Medianizer", accounts => {
     it('should return correct median of oracles when only 5 are set', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.bitstamp.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
-      await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinbase.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
       const read = await this.med.read.call()
@@ -142,39 +142,39 @@ contract("Medianizer", accounts => {
     it('should return correct median of all oracles when all oracles have same price', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.gemini.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.soChain.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.bitstamp.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
-      await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinbase.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
-      await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.cryptoWatch.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.cryptoWatch.__callback(padRight('0x', 64), '12529.71')
 
-      await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinpaprika.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinpaprika.__callback(padRight('0x', 64), '12529.71')
 
-      await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.kraken.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       const read = await this.med.read.call()
@@ -185,39 +185,39 @@ contract("Medianizer", accounts => {
     it('should return correct median of all oracles when different prices', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12000', 'ether'), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('13000', 'ether'), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('14000', 'ether'), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.gemini.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('15000', 'ether'), { from: chainlink })
       await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.soChain.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('16000', 'ether'), { from: chainlink })
       await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.bitstamp.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '17000')
 
-      await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinbase.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinbase.__callback(padRight('0x', 64), '18000')
 
-      await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.cryptoWatch.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.cryptoWatch.__callback(padRight('0x', 64), '19000')
 
-      await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinpaprika.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinpaprika.__callback(padRight('0x', 64), '20000')
 
-      await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.kraken.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(padRight('0x', 64), '21000')
 
       const read = await this.med.read.call()
@@ -228,39 +228,39 @@ contract("Medianizer", accounts => {
     it('should not return median for oracles if 12 hours has passed since last update', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.gemini.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.soChain.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), toWei('12529.71', 'ether'), { from: chainlink })
       await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.bitstamp.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.bitstamp.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.bitstamp.__callback(padRight('0x', 64), '12529.71')
 
-      await this.coinbase.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinbase.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinbase.__callback(padRight('0x', 64), '12529.71')
 
-      await this.cryptoWatch.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.cryptoWatch.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.cryptoWatch.__callback(padRight('0x', 64), '12529.71')
 
-      await this.coinpaprika.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.coinpaprika.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.coinpaprika.__callback(padRight('0x', 64), '12529.71')
 
-      await this.kraken.pack(this.oraclizeBill, this.token.address, { from: updater })
+      await this.kraken.update(this.oraclizeBill, this.token.address, { from: updater })
       await this.kraken.__callback(padRight('0x', 64), '12529.71')
 
       await time.increase(43300)
@@ -276,23 +276,23 @@ contract("Medianizer", accounts => {
     it('should return median price of 0 if all oracle values are equal or above 2^128', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.gemini.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
       await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.soChain.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).toFixed(), { from: chainlink })
       await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
@@ -304,23 +304,23 @@ contract("Medianizer", accounts => {
     it('should return median price of 2^128-1 if all oracle values are equal to 2^128-1', async function() {
       await time.increase(901)
 
-      await this.blockchainInfo.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.blockchainInfo.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.blockchainInfo.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
       await this.blockchainInfo.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.coinMarketCap.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.coinMarketCap.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.coinMarketCap.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
       await this.coinMarketCap.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.cryptoCompare.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.cryptoCompare.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.cryptoCompare.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
       await this.cryptoCompare.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.gemini.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.gemini.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.gemini.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
       await this.gemini.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 
-      await this.soChain.pack(this.chainlinkBill, this.token.address, { from: updater })
+      await this.soChain.update(this.chainlinkBill, this.token.address, { from: updater })
       await this.soChain.returnAssetPrice(asciiToHex("9f0406209cf64acda32636018b33de11"), BigNumber(2).pow(128).minus(1).toFixed(), { from: chainlink })
       await this.soChain.returnPaymentTokenPrice(asciiToHex("35e428271aad4506afc4f4089ce98f68"), toWei('3.19', 'ether'), { from: chainlink })
 

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -61,7 +61,7 @@ contract("Oraclize", accounts => {
 
     await this.token.approve(this.med.address, toWei('100', 'ether'))
 
-    await this.med.push(toWei('100', 'ether'), this.token.address)
+    await this.med.fund(toWei('100', 'ether'), this.token.address)
 
     await this.weth.approve(this.coinbase.address, toWei('1', 'ether'), { from: updater })
   })

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -87,8 +87,8 @@ contract("Oraclize", accounts => {
       const read = await this.coinbase.read.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(read))
 
-      const lval = await this.coinbase.lval.call()
-      assert.equal(toWei('303.79', 'ether'), lval)
+      const paymentTokenPrice = await this.coinbase.paymentTokenPrice.call()
+      assert.equal(toWei('303.79', 'ether'), paymentTokenPrice)
 
       const peek = await this.coinbase.peek.call()
       assert.equal(toWei('12656.71', 'ether'), hexToNumberString(peek[0]))

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -70,17 +70,17 @@ contract("Oraclize", accounts => {
     it('should fail if trying to pack twice before 15 minutes is up', async function() {
       assert.equal(true, true)
 
-      await this.coinbase.pack(this.bill, this.token.address, { from: updater })
+      await this.coinbase.update(this.bill, this.token.address, { from: updater })
 
       await this.coinbase.__callback(padRight('0x', 64), "12529.71")
 
-      await expectRevert.unspecified(this.coinbase.pack(this.bill, this.token.address), { from: updater })
+      await expectRevert.unspecified(this.coinbase.update(this.bill, this.token.address), { from: updater })
     })
 
     it('should succeed in updating price of called once', async function() {
       await time.increase(901)
 
-      await this.coinbase.pack(this.bill, this.token.address, { from: updater })
+      await this.coinbase.update(this.bill, this.token.address, { from: updater })
 
       await this.coinbase.__callback(padRight('0x', 64), '12656.71')
 
@@ -98,7 +98,7 @@ contract("Oraclize", accounts => {
     it('should reward correctly', async function() {
       await time.increase(901)
 
-      await this.coinbase.pack(this.bill, this.token.address, { from: updater })
+      await this.coinbase.update(this.bill, this.token.address, { from: updater })
 
       const balBefore = await this.token.balanceOf.call(updater)
 
@@ -112,7 +112,7 @@ contract("Oraclize", accounts => {
     it('should not reward if price has not changed by 1%', async function() {
       await time.increase(901)
 
-      await this.coinbase.pack(this.bill, this.token.address, { from: updater })
+      await this.coinbase.update(this.bill, this.token.address, { from: updater })
 
       const balBefore = await this.token.balanceOf.call(updater)
 
@@ -124,7 +124,7 @@ contract("Oraclize", accounts => {
 
       await time.increase(901)
 
-      await this.coinbase.pack(this.bill, this.token.address, { from: updater })
+      await this.coinbase.update(this.bill, this.token.address, { from: updater })
 
       const balBefore2 = await this.token.balanceOf.call(updater)
 


### PR DESCRIPTION
### Description

This PR improves naming throughout the Medianizer and Oracles

### Submission Checklist :pencil:

- [x] Rename `Medianizer.set` to `Medianizer.setOracles`
- [x] Rename `setMax` to `setMaxReward`
- [x] Rename `own` to `deployer`
- [x] Rename `Medianizer.values` to `Medianizer.oracles`
- [x] Rename `Medianizer.push` to `Medianizer.fund`
- [x] Rename `Medianizer.val`, `Medianizer.has` to `Medianizer.assetPrice`, `Medianizer.hasPrice`
- [x] Rename `val`, `lval` to `assetPrice`, `paymentTokenPrice`
- [x] Rename `min` to `minOraclesRequired`
- [x] Rename `zzz`, `lag` to `expiry`, `timeout`
- [x] Rename `gain` to `rewardAmount`
- [x] Rename `Areq`, `areqs` to `AsyncRequest`, `asyncRequests`
- [x] Rename `owed` to `rewardee`
- [x] Rename `pmt`, `dis` to `payment`, `disbursement`
- [x] Rename `tok` to `token`
- [x] Rename `post`, `tell`, `posted`, `told` to `setAssetPrice`, `setPaymentTokenPrice`, `assetPriceSet`, `paymentTokenPriceSet`
- [x] Rename `ward` to `rename`
- [x] Rename `call` to `getAssetPrice`
- [x] Rename `chec` to `getPaymentTokenPrice`
- [x] Rename `cur`, `sup` to `returnAssetPrice`, `returnPaymentTokenPrice`
- [x] Rename `pack` to `update`
- [x] Add glossary to `README.md`