### PR TITLE
QSP-6 Fix undocumented magic constants

### DIFF
--- a/contracts/chainlink/BlockchainInfo.sol
+++ b/contracts/chainlink/BlockchainInfo.sol
@@ -17,8 +17,8 @@ contract BlockchainInfo is ChainLink {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://blockchain.info/ticker?currency=USD");
         req.add("path", "USD.last");
-        req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        queryId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
@@ -27,8 +27,8 @@ contract BlockchainInfo is ChainLink {
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
-        req.addInt("times", 1000000000000000000);
-        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
         linkIdToQueryId[linkId] = queryId;
         return linkId;
     }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -11,6 +11,9 @@ contract ChainLink is ChainlinkClient, Oracle {
 
     bytes32 public lastQueryId;
 
+    uint256 public constant DEFAULT_LINK_PAYMENT = 2 * LINK; // Default link payment
+    uint256 public constant ORACLE_EXPIRY = 12 hours; // Oracle expiry (price needs to be updated every 12 hours to be considered up to date)
+
     mapping(bytes32 => bytes32) linkIdToQueryId;
 
     constructor(Medianizer med_, ERC20 link_, address oracle_)
@@ -20,7 +23,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         link = link_;
         setChainlinkToken(address(link_));
         setChainlinkOracle(oracle_);
-        asyncRequests[lastQueryId].payment = uint128(2 * LINK);
+        asyncRequests[lastQueryId].payment = uint128(DEFAULT_LINK_PAYMENT);
     }
 
     function bill() public view returns (uint256) {
@@ -48,7 +51,7 @@ contract ChainLink is ChainlinkClient, Oracle {
         public
         recordChainlinkFulfillment(_requestId)
     {
-        setAssetPrice(_requestId, uint128(_price), uint32(now + 43200));
+        setAssetPrice(_requestId, uint128(_price), uint32(now + ORACLE_EXPIRY));
     }
     
     function returnPaymentTokenPrice(bytes32 _requestId, uint256 _price) // Supply Currency

--- a/contracts/chainlink/CoinMarketCap.sol
+++ b/contracts/chainlink/CoinMarketCap.sol
@@ -22,8 +22,8 @@ contract CoinMarketCap is ChainLink {
         path[3] = "USD";
         path[4] = "price";
         req.addStringArray("copyPath", path);
-        req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        queryId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
@@ -37,8 +37,8 @@ contract CoinMarketCap is ChainLink {
         path[3] = "USD";
         path[4] = "price";
         req.addStringArray("copyPath", path);
-        req.addInt("times", 1000000000000000000);
-        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
         linkIdToQueryId[linkId] = queryId;
         return linkId;
     }

--- a/contracts/chainlink/CryptoCompare.sol
+++ b/contracts/chainlink/CryptoCompare.sol
@@ -17,8 +17,8 @@ contract CryptoCompare is ChainLink {
         req.add("fsym", "BTC");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
-        req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        queryId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
@@ -27,8 +27,8 @@ contract CryptoCompare is ChainLink {
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
-        req.addInt("times", 1000000000000000000);
-        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
         linkIdToQueryId[linkId] = queryId;
         return linkId;
     }

--- a/contracts/chainlink/Gemini.sol
+++ b/contracts/chainlink/Gemini.sol
@@ -17,8 +17,8 @@ contract Gemini is ChainLink {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://api.gemini.com/v1/pubticker/btcusd");
         req.add("path", "last");
-        req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        queryId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
@@ -27,8 +27,8 @@ contract Gemini is ChainLink {
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
-        req.addInt("times", 1000000000000000000);
-        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
         linkIdToQueryId[linkId] = queryId;
         return linkId;
     }

--- a/contracts/chainlink/SoChain.sol
+++ b/contracts/chainlink/SoChain.sol
@@ -17,8 +17,8 @@ contract SoChain is ChainLink {
         Chainlink.Request memory req = buildChainlinkRequest(UINT256_MUL_JOB, this, this.returnAssetPrice.selector);
         req.add("get", "https://chain.so/api/v2/get_info/BTC");
         req.add("path", "data.price");
-        req.addInt("times", 1000000000000000000);
-        queryId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        queryId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
     }
 
     function getPaymentTokenPrice(uint128 payment, bytes32 queryId) internal returns (bytes32) {
@@ -27,8 +27,8 @@ contract SoChain is ChainLink {
         req.add("fsym", "LINK");
         req.add("tsyms", "USD");
         req.add("copyPath", "USD");
-        req.addInt("times", 1000000000000000000);
-        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2));
+        req.addInt("times", WAD); // Convert string from API to WAD
+        bytes32 linkId = sendChainlinkRequest(req, div(payment, 2)); // Divide by 2 so that payment covers both asset price and asset token price
         linkIdToQueryId[linkId] = queryId;
         return linkId;
     }


### PR DESCRIPTION
### Description

This PR documents undocumented magic constants. 

### Submission Checklist :pencil:

- [x] Add `DEFAULT_LINK_PAYMENT` to `ChainLink.sol`
- [x] Add `ORACLE_EXPIRY` to `ChainLink.sol`
- [x] Use `WAD` instead of `1000000000000000000` for `BlockchainInfo.sol`, `CoinMarketCap.sol`, `CryptoCompare.sol`, `Gemini.sol`, `SoChain.sol`
- [x] Add explanation of `div(payment, 2)` in comments
