### PR TITLE
QSP-9 Ensure downcasting in Medianizer.fund

### DIFF
--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -59,8 +59,9 @@ contract Medianizer is DSMath {
     }
 
     function fund (uint256 amount, ERC20 token) {
+      require(amount < 2**128-1); // Ensure amount fits in uint128
       for (uint256 i = 0; i < oracles.length; i++) {
-        require(token.transferFrom(msg.sender, address(oracles[i]), uint(div(uint128(amount), uint128(oracles.length)))));
+        require(token.transferFrom(msg.sender, address(oracles[i]), uint(hdiv(uint128(amount), uint128(oracles.length)))));
       }
     }
 

--- a/test/medianizer.js
+++ b/test/medianizer.js
@@ -270,6 +270,10 @@ contract("Medianizer", accounts => {
       const peek = await this.med.peek.call()
       assert.equal(peek[1], false)
     })
+
+    it('should fail if amount is greater than 2**128-1', async function() {
+      await expectRevert(this.med.fund(BigNumber(2).pow(128).toFixed(), this.token.address), 'VM Exception while processing transaction: revert')
+    })
   })
 
   describe('compute', function() {


### PR DESCRIPTION
### Description

This PR ensures `amount` fits in `uint128` and use `hdiv` in `Medianizer.fund`

### Submission Checklist :pencil:

- [x] Ensure `amount` fits in `uint128` in `Medianizer.fund`
- [x] Use `hdiv` for `uint128` values in `Medianizer.fund`
