### PR TITLE
Implement set gas limit for oraclize

### DIFF
--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -11,6 +11,9 @@ contract Medianizer is DSMath {
     bool on;
     address deployer;
 
+    uint256 constant public MIN_ORACLIZE_GAS_LIMIT = 200000;
+    uint256 constant public MAX_ORACLIZE_GAS_LIMIT = 1000000;
+
     Oracle[] public oracles;
 
     constructor() public {
@@ -61,6 +64,31 @@ contract Medianizer is DSMath {
         oracles[7].setMaxReward(maxReward_);
         oracles[8].setMaxReward(maxReward_);
         oracles[9].setMaxReward(maxReward_);
+    }
+    // ======================================================================
+
+    // NOTE: THE FOLLOWING FUNCTION ALLOW THE GAS LIMIT TO BE MODIFIED BY THE
+    //       DEPLOYER, SINCE ORACLIZE ORACLES HAVE A MINIMUM GAS LIMIT OF
+    //       200,000 AND THERE COULD BE CASES WHERE THERE IS NOT ENOUGH GAS TO
+    //       COVER UPDATING THE PRICE. THE GAS LIMIT CAN BE CHANGED BETWEEN
+    //       A MINIMUM OF 200,000 GAS AND A MAXIMUM OF 1,000,000 GAS.
+    // ======================================================================
+
+    function setGasLimit(uint256 gasLimit_) public {
+        require(on, "Funds.setGasLimit: Oracles not set");
+        require(msg.sender == deployer, "Funds.setGasLimit: msg.sender isn't deployer");
+        require(gasLimit_ >= MIN_ORACLIZE_GAS_LIMIT, "Funds.setGasLimit: gasLimit_ cannot be less than min oraclize gas limit");
+        require(gasLimit_ <= MAX_ORACLIZE_GAS_LIMIT, "Funds.setGasLimit: gasLimit_ cannot be greater than max oraclize gas limit");
+        oracles[0].setGasLimit(gasLimit_);
+        oracles[1].setGasLimit(gasLimit_);
+        oracles[2].setGasLimit(gasLimit_);
+        oracles[3].setGasLimit(gasLimit_);
+        oracles[4].setGasLimit(gasLimit_);
+        oracles[5].setGasLimit(gasLimit_);
+        oracles[6].setGasLimit(gasLimit_);
+        oracles[7].setGasLimit(gasLimit_);
+        oracles[8].setGasLimit(gasLimit_);
+        oracles[9].setGasLimit(gasLimit_);
     }
     // ======================================================================
 

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -69,4 +69,6 @@ contract Oracle is DSMath {
     }
 
     function setMaxReward(uint256 maxReward_) public;
+
+    function setGasLimit(uint256 gasLimit_) public;
 }

--- a/contracts/chainlink/ChainLink.sol
+++ b/contracts/chainlink/ChainLink.sol
@@ -72,4 +72,8 @@ contract ChainLink is ChainlinkClient, Oracle {
         require(msg.sender == address(med), "ChainLink.setMaxReward: msg.sender isn't medianizer address");
         maxReward = maxReward_;
     }
+
+    function setGasLimit(uint256 gasLimit_) public {
+        require(msg.sender == address(med), "Oraclize.setGasLimit: msg.sender isn't medianizer address");
+    }
 }

--- a/contracts/oraclize/Bitstamp.sol
+++ b/contracts/oraclize/Bitstamp.sol
@@ -12,7 +12,7 @@ contract Bitstamp is Oraclize {
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment_);
-        require(oraclize_getPrice("URL") <= address(this).balance, "Bitstamp.getAssetPrice: Ether balance is less than oraclize price");
-        queryId = oraclize_query("URL", "json(https://www.bitstamp.net/api/v2/ticker/btcusd).last");
+        require(oraclize_getPrice("URL", gasLimit) <= address(this).balance, "Bitstamp.getAssetPrice: Ether balance is less than oraclize price");
+        queryId = oraclize_query("URL", "json(https://www.bitstamp.net/api/v2/ticker/btcusd).last", gasLimit);
     }
 }

--- a/contracts/oraclize/Coinbase.sol
+++ b/contracts/oraclize/Coinbase.sol
@@ -12,7 +12,7 @@ contract Coinbase is Oraclize {
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment_);
-        require(oraclize_getPrice("URL") <= address(this).balance, "Coinbase.getAssetPrice: Ether balance is less than oraclize price");
-        queryId = oraclize_query("URL", "json(https://api.pro.coinbase.com/products/BTC-USD/ticker).price");
+        require(oraclize_getPrice("URL", gasLimit) <= address(this).balance, "Coinbase.getAssetPrice: Ether balance is less than oraclize price");
+        queryId = oraclize_query("URL", "json(https://api.pro.coinbase.com/products/BTC-USD/ticker).price", gasLimit);
     }
 }

--- a/contracts/oraclize/Coinpaprika.sol
+++ b/contracts/oraclize/Coinpaprika.sol
@@ -12,7 +12,7 @@ contract Coinpaprika is Oraclize {
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment_);
-        require(oraclize_getPrice("URL") <= address(this).balance, "Coinpaprika.getAssetPrice: Ether balance is less than oraclize price");
-        queryId = oraclize_query("URL", "json(https://api.coinpaprika.com/v1/tickers/btc-bitcoin).quotes.USD.price");
+        require(oraclize_getPrice("URL", gasLimit) <= address(this).balance, "Coinpaprika.getAssetPrice: Ether balance is less than oraclize price");
+        queryId = oraclize_query("URL", "json(https://api.coinpaprika.com/v1/tickers/btc-bitcoin).quotes.USD.price", gasLimit);
     }
 }

--- a/contracts/oraclize/CryptoWatch.sol
+++ b/contracts/oraclize/CryptoWatch.sol
@@ -12,7 +12,7 @@ contract CryptoWatch is Oraclize {
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment_);
-        require(oraclize_getPrice("URL") <= address(this).balance, "CryptoWatch.getAssetPrice: Ether balance is less than oraclize price");
-        queryId = oraclize_query("URL", "json(https://api.cryptowat.ch/markets/coinbase-pro/btcusd/price).result.price");
+        require(oraclize_getPrice("URL", gasLimit) <= address(this).balance, "CryptoWatch.getAssetPrice: Ether balance is less than oraclize price");
+        queryId = oraclize_query("URL", "json(https://api.cryptowat.ch/markets/coinbase-pro/btcusd/price).result.price", gasLimit);
     }
 }

--- a/contracts/oraclize/Kraken.sol
+++ b/contracts/oraclize/Kraken.sol
@@ -12,7 +12,7 @@ contract Kraken is Oraclize {
         internal returns (bytes32 queryId)
     {
         weth.withdraw(payment_);
-        require(oraclize_getPrice("URL") <= address(this).balance, "Kraken.getAssetPrice: Ether balance is less than oraclize price");
-        queryId = oraclize_query("URL", "json(https://api.kraken.com/0/public/Ticker?pair=XBTUSD).result.XXBTZUSD.c.0");
+        require(oraclize_getPrice("URL", gasLimit) <= address(this).balance, "Kraken.getAssetPrice: Ether balance is less than oraclize price");
+        queryId = oraclize_query("URL", "json(https://api.kraken.com/0/public/Ticker?pair=XBTUSD).result.XXBTZUSD.c.0", gasLimit);
     }
 }

--- a/contracts/oraclize/Oraclize.sol
+++ b/contracts/oraclize/Oraclize.sol
@@ -9,6 +9,8 @@ contract Oraclize is usingOraclize, Oracle {
     WETH weth;
     MedianizerInterface medm;
 
+    uint256 public gasLimit = 200000;
+
     constructor(MedianizerInterface med_, MedianizerInterface medm_, WETH weth_)
         public
     {
@@ -24,12 +26,12 @@ contract Oraclize is usingOraclize, Oracle {
     function () public payable { }
 
     function bill() public view returns (uint256) {
-        return oraclize_getPrice("URL");
+        return oraclize_getPrice("URL", gasLimit);
     }
 
     function update(uint128 payment_, ERC20 token_) public { // payment
         require(uint32(now) > timeout, "Oraclize.update: now is less than timeout");
-        require(payment_ == oraclize_getPrice("URL"), "Oraclize.update: payment doesn't equal oraclize_getPrice");
+        require(payment_ == oraclize_getPrice("URL", gasLimit), "Oraclize.update: payment doesn't equal oraclize_getPrice");
         require(weth.transferFrom(msg.sender, address(this), uint(payment_)), "Oraclize.update: failed to transfer weth from msg.sender");
         bytes32 queryId = getAssetPrice(payment_);
         setPaymentTokenPrice(queryId, uint128(medm.read()));
@@ -50,5 +52,10 @@ contract Oraclize is usingOraclize, Oracle {
 
     function setMaxReward(uint256) public {
         require(msg.sender == address(med), "Oraclize.setMaxReward: msg.sender isn't medianizer address");
+    }
+
+    function setGasLimit(uint256 gasLimit_) public {
+        require(msg.sender == address(med), "Oraclize.setGasLimit: msg.sender isn't medianizer address");
+        gasLimit = gasLimit_;
     }
 }

--- a/contracts/test/OraclizeAPITesting.sol
+++ b/contracts/test/OraclizeAPITesting.sol
@@ -151,7 +151,8 @@ contract usingOraclize {
     }
 
     function oraclize_getPrice(string datasource, uint gaslimit) oraclizeAPI internal returns (uint){
-        return oraclize.getPrice(datasource, gaslimit);
+        return 3270000000000;
+        // return oraclize.getPrice(datasource, gaslimit);
     }
 
     function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
@@ -171,9 +172,10 @@ contract usingOraclize {
         return oraclize.query_withGasLimit.value(price)(timestamp, datasource, arg, gaslimit);
     }
     function oraclize_query(string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
-        uint price = oraclize.getPrice(datasource, gaslimit);
-        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
-        return oraclize.query_withGasLimit.value(price)(0, datasource, arg, gaslimit);
+        return bytes32(0);
+        // uint price = oraclize.getPrice(datasource, gaslimit);
+        // if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        // return oraclize.query_withGasLimit.value(price)(0, datasource, arg, gaslimit);
     }
     function oraclize_query(string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
         uint price = oraclize.getPrice(datasource);

--- a/test/oraclize.js
+++ b/test/oraclize.js
@@ -135,4 +135,22 @@ contract("Oraclize", accounts => {
       assert.equal(balAfter2 - balBefore2, 0)
     })
   })
+
+  describe('setGasLimit', function() {
+    it('should properly set gas limit', async function() {
+      const gasLimitBefore = 200000
+      const gasLimitAfter = 500000
+
+      await this.med.setGasLimit(gasLimitBefore, { from: own })
+
+      const actualGasLimitBefore = await this.coinbase.gasLimit.call()
+
+      await this.med.setGasLimit(gasLimitAfter, { from: own })
+
+      const actualGasLimitAfter = await this.coinbase.gasLimit.call()
+
+      expect(gasLimitBefore).to.equal(actualGasLimitBefore.toNumber())
+      expect(gasLimitAfter).to.equal(actualGasLimitAfter.toNumber())
+    })
+  })
 })


### PR DESCRIPTION
### Description

While testing it was discovered that it is possible that gas fees will exceed the default for oraclize of 200,000 gas. This PR allows for the deployer of the oracle contracts to change the gas limit for oraclize between 200,000 gas and 1,000,000 gas. 

### Submission Checklist :pencil:

- [x] Add `setGasLimit` for oraclize contracts
